### PR TITLE
Throw a proper error when the package with dataset is missing

### DIFF
--- a/R/mlr_tasks.R
+++ b/R/mlr_tasks.R
@@ -43,7 +43,7 @@ as.data.table.DictionaryTask = function(x, ...) {
 }
 
 load_dataset = function(id, package, keep.rownames = FALSE) {
-  if (!nzchar(find.package(package, quiet = TRUE)))
+  if (!length(find.package(package, quiet = TRUE)))
     stopf("Please install package '%s' for data set '%s'", package, id)
   ee = new.env(parent = emptyenv())
   data(list = id, package = package, envir = ee)

--- a/tests/testthat/test_Dictionary.R
+++ b/tests/testthat/test_Dictionary.R
@@ -52,3 +52,14 @@ test_that("Dictionaries are populated", {
     expect_data_table(as.data.table(mlr_measures), nrow = length(mlr_measures$keys()))
   }
 })
+
+test_that("Error when a package containing the dataset is not installed", {
+
+  test_task = DictionaryTask$new()
+  test_task$add("missing_package", function() {
+    b = DataBackendDataTable$new(data = load_dataset("xxx", "missing_package_123"))
+    TaskClassif$new("missing_package", b, target = "x", positive = "y")
+  })
+  expect_error(test_task$get("missing_package"))
+
+})


### PR DESCRIPTION
`!nzchar(find.package(package, quiet = TRUE))` returns an empty vector when the `package` is not installed. It causes a non-informative error message in `load_dataset`:

```
 Error in if (!nzchar(find.package(package, quiet = TRUE))) stopf("Please install package '%s' for data set '%s'",  : 
  argument is of length zero 
```

It might be better to change this to:
```
!length(find.package(package, quiet = TRUE))
```