### PR TITLE
Fix travis

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -1,8 +1,8 @@
 if (inherits(ci(), "TravisCI")) {
 
   get_stage("script") %>%
-    add_code_step(devtools::document()) %>%
     add_step(step_install_deps()) %>%
+    add_code_step(devtools::document()) %>%
     add_step(step_rcmdcheck(args = "--as-cran", error_on = "error"))
 }
 

--- a/tic.R
+++ b/tic.R
@@ -2,11 +2,13 @@ if (inherits(ci(), "TravisCI")) {
 
   get_stage("script") %>%
     add_code_step(devtools::document()) %>%
+    add_step(step_install_deps()) %>%
     add_step(step_rcmdcheck(args = "--as-cran", error_on = "error"))
 }
 
 if (inherits(ci(), "AppVeyorCI")) {
   get_stage("script") %>%
+    add_step(step_install_deps()) %>%
     add_step(step_rcmdcheck(args = c("--as-cran", "--no-manual", "--no-vignettes",
       "--no-build-vignettes"), build_args = c("--no-build-vignettes"), error_on = "error"))
 }


### PR DESCRIPTION
The installation step of deps was recently outsourced from the rcmdcheck step so that "less magic" is going on behind the scenes. Hence we need to explicitly specify it now.

Soon we will we able to use a one-line macro instead of chaining all these steps manually.