### PR TITLE
Trigger mlr3book CI run on every successful master build

### DIFF
--- a/inst/trigger-mlr3book.sh
+++ b/inst/trigger-mlr3book.sh
@@ -2,7 +2,7 @@ echo "TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
 if [[ ($TRAVIS_BRANCH == master) &&
       ($TRAVIS_PULL_REQUEST == false) ]] ; then
   curl -LO --retry 3 https://raw.github.com/mernst/plume-lib/master/bin/trigger-travis.sh
-  sh trigger-travis.sh mlr-org mlr3book $TRAVIS_ACCESS_TOKEN "trigger from mlr3"
+  sh trigger-travis.sh mlr-org mlr3book $TRAVIS_ACCESS_TOKEN "trigger from $TRAVIS_REPO_SLUG $TRAVIS_COMMIT"
 else
   echo "Not triggering a mlr3book deployment"
 fi

--- a/inst/trigger-mlr3book.sh
+++ b/inst/trigger-mlr3book.sh
@@ -3,4 +3,6 @@ if [[ ($TRAVIS_BRANCH == master) &&
       ($TRAVIS_PULL_REQUEST == false) ]] ; then
   curl -LO --retry 3 https://raw.github.com/mernst/plume-lib/master/bin/trigger-travis.sh
   sh trigger-travis.sh mlr-org mlr3book $TRAVIS_ACCESS_TOKEN "trigger from mlr3"
+else
+  echo "Not triggering a mlr3book deployment"
 fi

--- a/inst/trigger-mlr3book.sh
+++ b/inst/trigger-mlr3book.sh
@@ -1,0 +1,6 @@
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
+if [[ ($TRAVIS_BRANCH == master) &&
+      ($TRAVIS_PULL_REQUEST == false) ]] ; then
+  curl -LO --retry 3 https://raw.github.com/mernst/plume-lib/master/bin/trigger-travis.sh
+  sh trigger-travis.sh mlr-org mlr3book $TRAVIS_ACCESS_TOKEN "trigger from mlr3"
+fi

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_step(add_code_step(system("sh inst/trigger-mlr3book.sh"))))
+  add_step(add_code_step(system("sh inst/trigger-mlr3book.sh")))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_code_step(system("sh inst/trigger-mlr3book.sh"))
+  add_code_step(system('sh inst/trigger-mlr3book.sh'))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_step(add_code_step(system("sh inst/trigger-mlr3book.sh")))
+  add_code_step(system("sh inst/trigger-mlr3book.sh"))

--- a/tic.R
+++ b/tic.R
@@ -3,3 +3,6 @@ do_package_checks(error_on = "error")
 if (ci_has_env("BUILD_PKGDOWN")) {
   do_pkgdown(orphan = TRUE)
 }
+
+get_stage("after_success") %>%
+  add_step(step_run_code(system("sh inst/trigger-mlr3book.sh")))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_code_step(system("/usr/bin/bash ./inst/trigger-mlr3book.sh"))
+  add_code_step(system("bash ./inst/trigger-mlr3book.sh"))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_code_step(system(here::here('sh inst/trigger-mlr3book.sh')))
+  add_code_step(system("/usr/bin/bash ./inst/trigger-mlr3book.sh"))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_code_step(system('sh inst/trigger-mlr3book.sh'))
+  add_code_step(system(here::here('sh inst/trigger-mlr3book.sh')))

--- a/tic.R
+++ b/tic.R
@@ -5,4 +5,4 @@ if (ci_has_env("BUILD_PKGDOWN")) {
 }
 
 get_stage("after_success") %>%
-  add_step(step_run_code(system("sh inst/trigger-mlr3book.sh")))
+  add_step(add_code_step(system("sh inst/trigger-mlr3book.sh"))))


### PR DESCRIPTION
This change triggers a run of mlr3book on every successful Travis run on the master branch.

The mlr3book build will include the repo slug and the commit message so that we quickly see if a change in one of the repos triggered a failure of the book.

I described the heuristics in the [CI setup](https://www.notion.so/mlrorg/CI-setup-98e90e1eba044ff5ba576f2ffad768dc).