### PR TITLE
Move tic.R to submodule

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,4 +13,4 @@
 ^inst/extdata/.+\.R$
 ^README\.Rmd$
 ^revdep$
-mlr-ci/
+mlr-ci

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mlr-ci"]
 	path = mlr-ci
 	url = https://github.com/mlr-org/mlr-ci.git
+	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # DO NOT CHANGE THE CODE BELOW
 before_install:
-  - git submodule update --init --recursive --update --remote
+  - git submodule update --init --recursive --remote
   - R -q -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
   - R -q -e 'if (!requireNamespace("curl", quietly = TRUE)) install.packages("curl")'
   - R -q -e 'remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
@@ -30,6 +30,10 @@ dist: xenial
 cache: packages
 latex: true
 pandoc_version: 2.5
+# we run our our submodule clone command in the "before_install" stage
+# with defaults to the HEAD of the submodule
+git:
+  submodules: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # DO NOT CHANGE THE CODE BELOW
 before_install:
-  - git submodule init --recursive --update --remote
+  - git submodule update --init --recursive --update --remote
   - R -q -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
   - R -q -e 'if (!requireNamespace("curl", quietly = TRUE)) install.packages("curl")'
   - R -q -e 'remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ pandoc_version: 2.5
 # with defaults to the HEAD of the submodule
 git:
   submodules: false
+  clone: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ after_success: R -q -e 'tic::after_success()'
 after_failure: R -q -e 'tic::after_failure()'
 before_deploy: R -q -e 'tic::before_deploy()'
 deploy:
-  provider: script
-  script: R -q -e 'tic::deploy()'
-  on:
-    all_branches: true
+  - ls
+  - git submodule update --init --recursive --remote
+  - R -q -e 'tic::deploy()'
 after_deploy: R -q -e 'tic::after_deploy()'
 after_script: R -q -e 'tic::after_script()'
 # DO NOT CHANGE THE CODE ABOVE

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ deploy:
   script: R -q -e 'tic::deploy()'
   on:
     all_branches: true
-    skip_cleanup: true
 after_deploy: R -q -e 'tic::after_deploy()'
 after_script: R -q -e 'tic::after_script()'
 # DO NOT CHANGE THE CODE ABOVE
@@ -30,7 +29,6 @@ sudo: false
 dist: xenial
 cache: packages
 latex: true
-pandoc_version: 2.5
 # we run our our submodule clone command in the "before_install" stage
 # with defaults to the HEAD of the submodule
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ pandoc_version: 2.5
 # with defaults to the HEAD of the submodule
 git:
   submodules: false
-  clone: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ after_success: R -q -e 'tic::after_success()'
 after_failure: R -q -e 'tic::after_failure()'
 before_deploy: R -q -e 'tic::before_deploy()'
 deploy:
-  - ls
-  - git submodule update --init --recursive --remote
-  - R -q -e 'tic::deploy()'
+  provider: script
+  script: R -q -e 'tic::deploy()'
+  on:
+    all_branches: true
+    skip_cleanup: true
 after_deploy: R -q -e 'tic::after_deploy()'
 after_script: R -q -e 'tic::after_script()'
 # DO NOT CHANGE THE CODE ABOVE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ after_failure: R -q -e 'tic::after_failure()'
 before_deploy: R -q -e 'tic::before_deploy()'
 deploy:
   provider: script
-  script: R -q -e 'tic::deploy()'
+  script:
+    - git submodule update --init --recursive --remote
+    - R -q -e 'tic::deploy()'
   on:
     all_branches: true
 after_deploy: R -q -e 'tic::after_deploy()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ after_failure: R -q -e 'tic::after_failure()'
 before_deploy: R -q -e 'tic::before_deploy()'
 deploy:
   provider: script
-  script:
-    - git submodule update --init --recursive --remote
-    - R -q -e 'tic::deploy()'
+  script: R -q -e 'tic::deploy()'
   on:
     all_branches: true
 after_deploy: R -q -e 'tic::after_deploy()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # DO NOT CHANGE THE CODE BELOW
 before_install:
+  - git submodule init --recursive --update --remote
   - R -q -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
   - R -q -e 'if (!requireNamespace("curl", quietly = TRUE)) install.packages("curl")'
   - R -q -e 'remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'


### PR DESCRIPTION
Served from https://github.com/mlr-org/mlr-ci/.

- Updated in every CI build
- Adds ability to update the CI of all mlr3 repos via one submodule commit
- the `--remote` options ensures that always the latest state of the master branch of the submodule is fetched in every CI build (by default it would always be the current state of the respective repo containing the submodule)