### PR TITLE
Travis: Build on bionic instead of xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ after_script: R -q -e 'tic::after_script()'
 
 # Header
 language: r
-sudo: false
 dist: bionic
 cache: packages
 latex: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_script: R -q -e 'tic::after_script()'
 # Header
 language: r
 sudo: false
-dist: xenial
+dist: bionic
 cache: packages
 latex: true
 


### PR DESCRIPTION
Officially supported by Travis now and marked as "stable": https://docs.travis-ci.com/user/reference/linux/#using-ubuntu-linux-distributions