### PR TITLE
Add print option for ST* tasks

### DIFF
--- a/R/Task.R
+++ b/R/Task.R
@@ -593,6 +593,11 @@ task_print = function(self) {
   if ("weights" %in% self$properties) {
     catf(str_indent("* Weights:", roles$weight))
   }
+  if (!is.null(self$coordinate_names)) {
+    coords = self$coordinates()
+    cat("* Coordinates:\n")
+    print(coords)
+  }
 }
 
 # collect column information of a backend.


### PR DESCRIPTION
Until now we still had a modified copy of `task_print()` in {mlr3spatiotempcv}.

This change implements it upstream so that we can get rid of the copy and inherit all further upstream changes to `task_print()`.

Example

```
<TaskClassifST:ecuador> (751 x 11)
* Target: slides
* Properties: twoclass
* Features (10):
  - dbl (10): carea, cslope, dem, distdeforest, distroad, distslidespast, hcurv,
    log.carea, slope, vcurv
* Coordinates:
            x       y
  1: 712882.5 9560002
  2: 715232.5 9559582
  3: 715392.5 9560172
  4: 715042.5 9559312
  5: 715382.5 9560142
 ---                 
747: 714472.5 9558482
748: 713142.5 9560992
749: 713322.5 9560562
750: 715392.5 9557932
751: 713802.5 9560862
```

Edit: Oh dear, this breaks hundreds of tests... ;(
@mllg Is there a better way how we can achieve this? Or do we really need to adjust all tests?