### PR TITLE
set task_nrow in custom resampling (Fixes #451)

### DIFF
--- a/R/ResamplingCustom.R
+++ b/R/ResamplingCustom.R
@@ -51,6 +51,7 @@ ResamplingCustom = R6Class("ResamplingCustom", inherit = Resampling,
       assert_list(test_sets, types = "atomicvector", len = length(train_sets), any.missing = FALSE, null.ok = TRUE)
       self$instance = list(train = train_sets, test = test_sets)
       self$task_hash = task$hash
+      self$task_nrow = task$nrow
       invisible(self)
     }
   ),

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -162,6 +162,10 @@ test_that("custom resampling (#245)", {
   design = data.table(task = list(task_boston), learner = list(lrn), resampling = list(rdesc))
   bmr = benchmark(design)
   expect_benchmark_result(bmr)
+
+  # Issue #451
+  design = benchmark_grid(task = task_boston, learner = lrn, resampling = rdesc)
+  expect_data_table(design, nrows = 1)
 })
 
 test_that("extract params", {


### PR DESCRIPTION
Adresses the bug #451.
Apparently `self$task_nrow` was not set.

I think it is not optimal to not call `super$instantiate()` because all changes on `Resample$instantiate()` have to be copied here.
But `Resampling$instantiate()` relies on `private$.sample()` which we than had to *fake* for `ResamplingCustom` which also sounds weird.