### PR TITLE
Check for task/learner properties in `assert_learnable()`

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -105,6 +105,11 @@ assert_learnable = function(task, learner) {
   if (length(tmp)) {
     stopf("%s has the following unsupported feature types: %s", task$format(), str_collapse(tmp))
   }
+
+  tmp = setdiff(task$properties, learner$properties)
+  if (length(tmp)) {
+    stopf("%s has the following unsupported properties: %s", task$format(), str_collapse(tmp))
+  }
 }
 
 #' @export

--- a/R/worker.R
+++ b/R/worker.R
@@ -44,6 +44,7 @@ predict_wrapper = function(task, learner) {
 
 learner_train = function(learner, task, row_ids = NULL) {
   assert_task(task)
+  assert_learnable(task, learner)
 
   # subset to train set w/o cloning
   if (!is.null(row_ids)) {


### PR DESCRIPTION
fixes https://github.com/mlr-org/mlr3learners/issues/72

AFAICS all other calling functions (resample, benchmark()) call `assert_learnable()` already.

With this PR:

``` r
library(mlr3)
library(mlr3learners)

lrn("classif.log_reg")$properties
#> [1] "twoclass" "weights"
tsk("iris")$properties
#> [1] "multiclass"

lrn("classif.log_reg")$train(tsk("iris"))
#> Error: <TaskClassif:iris> has the following unsupported properties: multiclass
```

<sup>Created on 2020-03-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>