### PR TITLE
Testing parallelization

### DIFF
--- a/R/LearnerClassifDebug.R
+++ b/R/LearnerClassifDebug.R
@@ -89,7 +89,7 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
         get("attach")(structure(list(), class = "UserDefinedDatabase"))
       }
 
-      model = list(response = as.character(sample(task$truth(), 1L)))
+      model = list(response = as.character(sample(task$truth(), 1L)), pid = Sys.getpid())
       if (isTRUE(pv$save_tasks)) {
         model$task_train = task$clone(deep = TRUE)
       }

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -257,3 +257,14 @@ test_that("filter", {
   bmr$filter(resampling_ids = "cv")
   expect_data_table(bmr$data, nrows = 3)
 })
+
+test_that("parallelization works", {
+  skip_if_not_installed("future")
+  library("future")
+  grid = benchmark_grid(list(tsk("wine"), tsk("sonar")), replicate(2, lrn("classif.debug")), rsmp("cv", folds = 2))
+  njobs = nrow(grid) * 2
+  plan(multiprocess, workers = njobs)
+  bmr = benchmark(grid, store_models = TRUE)
+  pids = map_int(bmr$data$learner, function(x) x$model$pid)
+  expect_equal(length(unique(pids)), njobs)
+})

--- a/tests/testthat/test_mlr_learners_classif_debug.R
+++ b/tests/testthat/test_mlr_learners_classif_debug.R
@@ -29,7 +29,7 @@ test_that("updating model works / resample", {
   learner = lrn("classif.debug", save_tasks = TRUE)
   rr = resample(tsk("iris"), learner, rsmp("holdout"), store_models = TRUE)
   new_learner = rr$learners[[1]]
-  expect_list(new_learner$model, len = 3)
+  expect_list(new_learner$model, len = 4)
 })
 
 test_that("NA predictions", {


### PR DESCRIPTION
A small test that checks wheter `future::plan` enables prallelization correctly for `benchmark()`. The change of the *debug learner* also would allow tests for correct parallelization in more complicated setups.

Note: There might be conflict once [this branch](https://github.com/mlr-org/mlr3/tree/test-future) should be merged, because it uses future to parallelize the tests.