### PR TITLE
Update helper_autotest.R

### DIFF
--- a/inst/testthat/helper_autotest.R
+++ b/inst/testthat/helper_autotest.R
@@ -289,8 +289,8 @@ run_experiment = function(task, learner, seed = NULL) {
     }
 
     if ("oob_error" %in% learner$properties) {
-      err = learner$oob_error()
-      msg = checkmate::check_number(err)
+      oob = learner$oob_error()
+      msg = checkmate::check_number(oob)
       if (!isTRUE(msg))
         return(err(msg))
     }


### PR DESCRIPTION
I've found that if the oob error is incorrectly implemented and returns NULL then because it was called `err` here, it causes the `err` function to be masked and a helpful error message is not returned.