### PR TITLE
Style package with new {mlr.styler} package

### DIFF
--- a/R/BenchmarkResult.R
+++ b/R/BenchmarkResult.R
@@ -270,7 +270,7 @@ BenchmarkResult = R6Class("BenchmarkResult",
       tab = insert_named(tab, scores)
 
       cns = c("uhash", "nr", "resample_result", "task_id", "learner_id", "resampling_id", "iters",
-          "warnings", "errors", "params", ids(measures))
+        "warnings", "errors", "params", ids(measures))
       cns = intersect(cns, names(tab))
       tab[, cns, with = FALSE]
     },
@@ -302,10 +302,11 @@ BenchmarkResult = R6Class("BenchmarkResult",
       learner_phashes = NULL
 
       filter_if_not_null = function(column, hashes) {
-        if (is.null(hashes))
+        if (is.null(hashes)) {
           fact
-        else
+        } else {
           fact[unique(hashes), on = column, nomatch = NULL]
+        }
       }
 
 

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -244,8 +244,9 @@ Learner = R6Class("Learner",
       }
 
       pdata = learner_predict(self, task, row_ids)
-      if (is.null(pdata))
+      if (is.null(pdata)) {
         return(NULL)
+      }
 
       as_prediction(check_prediction_data(pdata))
     },
@@ -269,8 +270,9 @@ Learner = R6Class("Learner",
       newdata = as.data.table(assert_data_frame(newdata, min.rows = 1L))
 
       if (is.null(task)) {
-        if (is.null(self$state$train_task))
+        if (is.null(self$state$train_task)) {
           stopf("No task stored, and no task provided")
+        }
         task = self$state$train_task$clone()
       } else {
         task = assert_task(as_task(task, clone = TRUE))
@@ -414,7 +416,10 @@ Learner = R6Class("Learner",
       switch(name,
         .param_set = value$clone(deep = TRUE),
         fallback = if (is.null(value)) NULL else value$clone(deep = TRUE),
-        state = { value$log = copy(value$log); value },
+        state = {
+          value$log = copy(value$log)
+          value
+        },
         value
       )
     }

--- a/R/LearnerClassifDebug.R
+++ b/R/LearnerClassifDebug.R
@@ -152,8 +152,13 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
         if (!is.null(pv$predict_missing)) {
           ii = sample.int(n, n * pv$predict_missing)
           prob = switch(missing_type,
-            "na" = { prob[ii, ] = NA_real_; prob },
-            "omit" = { prob[ii,, drop = FALSE] }
+            "na" = {
+              prob[ii, ] = NA_real_
+              prob
+            },
+            "omit" = {
+              prob[ii, , drop = FALSE]
+            }
           )
         }
       }

--- a/R/MeasureDebug.R
+++ b/R/MeasureDebug.R
@@ -51,8 +51,9 @@ MeasureDebug = R6Class("MeasureDebug",
   private = list(
     .score = function(prediction, ...) {
       na_ratio = self$param_set$get_values()$na_ratio
-      if (na_ratio > runif(1L))
+      if (na_ratio > runif(1L)) {
         return(NA_integer_)
+      }
       length(prediction$row_ids)
     }
   )

--- a/R/PredictionDataClassif.R
+++ b/R/PredictionDataClassif.R
@@ -90,7 +90,7 @@ c.PredictionDataClassif = function(..., keep_duplicates = TRUE) {
   if (!keep_duplicates) {
     keep = !duplicated(tab, by = "row_ids", fromLast = TRUE)
     tab = tab[keep]
-    prob = prob[keep,, drop = FALSE]
+    prob = prob[keep, , drop = FALSE]
   }
 
   result = as.list(tab)

--- a/R/ResampleResult.R
+++ b/R/ResampleResult.R
@@ -138,7 +138,7 @@ ResampleResult = R6Class("ResampleResult",
         set(tab, j = "learner_id", value = ids(tab[["learner"]]))
         set(tab, j = "resampling_id", value = ids(tab[["resampling"]]))
         setcolorder(tab, c("task", "task_id", "learner", "learner_id", "resampling", "resampling_id",
-            "iteration", "prediction"))
+          "iteration", "prediction"))
       }
 
       if (conditions) {
@@ -213,8 +213,9 @@ ResampleResult = R6Class("ResampleResult",
     task = function(rhs) {
       assert_ro_binding(rhs)
       tab = private$.data$tasks(private$.view)
-      if (nrow(tab) == 0L)
+      if (nrow(tab) == 0L) {
         return(NULL)
+      }
       tab$task[[1L]]
     },
 
@@ -224,8 +225,9 @@ ResampleResult = R6Class("ResampleResult",
     learner = function(rhs) {
       assert_ro_binding(rhs)
       tab = private$.data$learners(private$.view, states = FALSE)
-      if (nrow(tab) == 0L)
+      if (nrow(tab) == 0L) {
         return(NULL)
+      }
       tab$learner[[1L]]
     },
 
@@ -234,8 +236,9 @@ ResampleResult = R6Class("ResampleResult",
     resampling = function(rhs) {
       assert_ro_binding(rhs)
       tab = private$.data$resamplings(private$.view)
-      if (nrow(tab) == 0L)
+      if (nrow(tab) == 0L) {
         return(NULL)
+      }
       tab$resampling[[1L]]
     },
 

--- a/R/ResamplingHoldout.R
+++ b/R/ResamplingHoldout.R
@@ -72,7 +72,8 @@ ResamplingHoldout = R6Class("ResamplingHoldout", inherit = Resampling,
 
     .combine = function(instances) {
       list(train = do.call(c, map(instances, "train")), test = do.call(c, map(instances, "test")))
-    })
+    }
+  )
 )
 
 #' @include mlr_resamplings.R

--- a/R/ResultData.R
+++ b/R/ResultData.R
@@ -295,18 +295,20 @@ ResultData = R6Class("ResultData",
     #'   Returns `NULL` if the [ResultData] is empty.
     task_type = function() {
       tab = self$data$tasks
-      if (nrow(tab))
+      if (nrow(tab)) {
         tab$task[[1L]]$task_type
-      else
+      } else {
         NULL
+      }
     }
   ),
 
   private = list(
     get_view_index = function(view) {
-      if (is.null(view))
+      if (is.null(view)) {
         return(TRUE)
-       self$data$fact[list(view), on = "uhash", nomatch = NULL, which = TRUE]
+      }
+      self$data$fact[list(view), on = "uhash", nomatch = NULL, which = TRUE]
     },
 
     deep_clone = function(name, value) {
@@ -382,8 +384,8 @@ reassemble_learners = function(learners, states = NULL, param_vals = NULL) {
   learners = lapply(learners, function(l) l$clone(deep = TRUE))
 
   if (!is.null(states)) {
-     Map(function(l, s) {
-       l$state = s
+    Map(function(l, s) {
+      l$state = s
     }, l = learners, s = states)
   }
 

--- a/R/Task.R
+++ b/R/Task.R
@@ -351,8 +351,8 @@ Task = R6Class("Task",
 
         ci = self$col_info[list(keep_cols), on = "id"]
         data = do.call(data.table, Map(auto_convert,
-            value = as.list(data)[ci$id],
-            id = ci$id, type = ci$type, levels = ci$levels))
+          value = as.list(data)[ci$id],
+          id = ci$id, type = ci$type, levels = ci$levels))
 
         data = as_data_backend(data, primary_key = pk)
       } else {

--- a/R/TaskClassif_penguins.R
+++ b/R/TaskClassif_penguins.R
@@ -35,7 +35,7 @@ load_task_penguins = function() {
   penguins = as.data.table(palmerpenguins::penguins)
   setnames(penguins,
     old = c("bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g"),
-    new = c("bill_length",    "bill_depth",    "flipper_length",    "body_mass")
+    new = c("bill_length", "bill_depth", "flipper_length", "body_mass")
   )
 
   b = as_data_backend(penguins)

--- a/R/TaskGeneratorMoons.R
+++ b/R/TaskGeneratorMoons.R
@@ -58,7 +58,7 @@ TaskGeneratorMoons = R6Class("TaskGeneratorMoons",
 
       data.table(
         y = factor(rep(c("A", "B"), c(n1, n2)), levels = c("A", "B")),
-        x1 = 5  * cos(x) + rnorm(n, mean = mu, sd = sigma),
+        x1 = 5 * cos(x) + rnorm(n, mean = mu, sd = sigma),
         x2 = 10 * sin(x) + rnorm(n, mean = mu, sd = sigma)
       )
     },

--- a/R/TaskSupervised.R
+++ b/R/TaskSupervised.R
@@ -19,7 +19,7 @@
 #' @export
 #' @examples
 #' TaskSupervised$new("penguins", task_type = "classif", backend = palmerpenguins::penguins,
-#'     target = "species")
+#'   target = "species")
 TaskSupervised = R6Class("TaskSupervised", inherit = Task,
   public = list(
 

--- a/R/as_prediction_data.R
+++ b/R/as_prediction_data.R
@@ -35,8 +35,9 @@ as_prediction_data.list = function(x, task, row_ids = task$row_ids, check = TRUE
   assert_names(names(x), subset.of = predict_types)
 
   x$row_ids = row_ids
-  if (inherits(task, "TaskSupervised"))
+  if (inherits(task, "TaskSupervised")) {
     x$truth = task$truth(row_ids)
+  }
 
   pdata = new_prediction_data(x, task_type = task$task_type)
   if (check) {

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -282,7 +282,7 @@ assert_prediction_count = function(actual, expected, type) {
 
 assert_row_sums = function(prob) {
   for (i in seq_row(prob)) {
-    x = prob[i,, drop = TRUE]
+    x = prob[i, , drop = TRUE]
     n_missing = count_missing(x)
     if (n_missing > 0L && n_missing < length(x)) {
       stopf("Probabilities for observation %i are partly missing", i)

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -175,8 +175,9 @@ assert_measure = function(measure, task = NULL, learner = NULL, .var.name = vnam
 #' @rdname mlr_assertions
 assert_measures = function(measures, task = NULL, learner = NULL, .var.name = vname(measures)) {
   lapply(measures, assert_measure, task = task, learner = learner, .var.name = .var.name)
-  if (anyDuplicated(ids(measures)))
+  if (anyDuplicated(ids(measures))) {
     stopf("Measures need to have unique IDs")
+  }
   invisible(measures)
 }
 
@@ -281,7 +282,7 @@ assert_prediction_count = function(actual, expected, type) {
 
 assert_row_sums = function(prob) {
   for (i in seq_row(prob)) {
-    x = prob[i,, drop = TRUE]
+    x = prob[i, , drop = TRUE]
     if (anyMissing(x)) {
       if (!allMissing(x)) {
         stopf("Probabilities for observation %i are partly missing", i)

--- a/R/auto_convert.R
+++ b/R/auto_convert.R
@@ -5,21 +5,35 @@ mlr_reflections$auto_converters = ee = new.env(parent = emptyenv())
 
 ## from: logical
 ee[["logical___integer"]] =
-  function(value, type, levels) { as.integer(value) }
+  function(value, type, levels) {
+    as.integer(value)
+  }
 ee[["logical___numeric"]] =
-  function(value, type, levels) { as.double(value) }
+  function(value, type, levels) {
+    as.double(value)
+  }
 ee[["logical___character"]] =
-  function(value, type, levels) { as.character(value) }
+  function(value, type, levels) {
+    as.character(value)
+  }
 ee[["logical___factor"]] =
-  function(value, type, levels) { factor(value, levels = union(levels, value), ordered = FALSE) }
+  function(value, type, levels) {
+    factor(value, levels = union(levels, value), ordered = FALSE)
+  }
 ee[["logical___ordered"]] =
-  function(value, type, levels) { if (all(value %in% c(NA_character_, levels))) factor(value, levels = levels, ordered = TRUE) else NULL }
+  function(value, type, levels) {
+    if (all(value %in% c(NA_character_, levels))) factor(value, levels = levels, ordered = TRUE) else NULL
+  }
 ee[["logical___POSIXct"]] =
-  function(value, type, levels) { if (allMissing(value)) .POSIXct(value, tz = "") else value }
+  function(value, type, levels) {
+    if (allMissing(value)) .POSIXct(value, tz = "") else value
+  }
 
 ## from: integer
 ee[["integer___logical"]] =
-  function(value, type, levels) { if (test_integerish(value, lower = 0L, upper = 1L)) as.logical(value) else value }
+  function(value, type, levels) {
+    if (test_integerish(value, lower = 0L, upper = 1L)) as.logical(value) else value
+  }
 ee[["integer___numeric"]] =
   ee[["logical___numeric"]]
 ee[["integer___character"]] =
@@ -35,7 +49,9 @@ ee[["integer___POSIXct"]] =
 ee[["numeric___logical"]] =
   ee[["integer___logical"]]
 ee[["numeric___integer"]] =
-  function(value, type, levels) { if (test_integerish(value)) as.integer(value) else value }
+  function(value, type, levels) {
+    if (test_integerish(value)) as.integer(value) else value
+  }
 ee[["numeric___character"]] =
   ee[["logical___character"]]
 ee[["numeric___factor"]] =
@@ -47,17 +63,26 @@ ee[["numeric___POSIXct"]] =
 
 ## from: character
 ee[["character___logical"]] =
-  function(value, type, levels) { if (all(value %in% c(NA_character_, "TRUE", "FALSE", "true", "false", "T", "F"))) as.logical(value) else value }
+  function(value, type, levels) {
+    if (all(value %in% c(NA_character_, "TRUE", "FALSE", "true", "false", "T", "F"))) as.logical(value) else value
+  }
 ee[["character___integer"]] =
-  function(value, type, levels) { if (allMissing(value)) as.integer(value) else value }
+  function(value, type, levels) {
+    if (allMissing(value)) as.integer(value) else value
+  }
 ee[["character___numeric"]] =
-  function(value, type, levels) { if (allMissing(value)) as.double(value) else value }
+  function(value, type, levels) {
+    if (allMissing(value)) as.double(value) else value
+  }
 ee[["character___factor"]] =
   ee[["logical___factor"]]
 ee[["character___ordered"]] =
   ee[["logical___ordered"]]
 ee[["character___POSIXct"]] =
-  function(value, type, levels) { x = try(as.POSIXct(value, ""), silent = TRUE); if (inherits(x, "try-error")) value else x }
+  function(value, type, levels) {
+    x = try(as.POSIXct(value, ""), silent = TRUE)
+    if (inherits(x, "try-error")) value else x
+  }
 
 ## from: factor
 ee[["factor___logical"]] =
@@ -65,9 +90,13 @@ ee[["factor___logical"]] =
 ee[["factor___character"]] =
   ee[["logical___character"]]
 ee[["factor___factor"]] =
-  function(value, type, levels) { factor(value, levels = union(levels, levels(value)), ordered = FALSE) }
+  function(value, type, levels) {
+    factor(value, levels = union(levels, levels(value)), ordered = FALSE)
+  }
 ee[["factor___ordered"]] =
-  function(value, type, levels) { if (all(levels(value) %in% levels)) factor(value, levels = levels, ordered = TRUE) else NULL }
+  function(value, type, levels) {
+    if (all(levels(value) %in% levels)) factor(value, levels = levels, ordered = TRUE) else NULL
+  }
 ee[["factor___POSIXct"]] =
   ee[["character___POSIXct"]]
 

--- a/R/benchmark_grid.R
+++ b/R/benchmark_grid.R
@@ -32,9 +32,8 @@
 #'
 #' # manual instantiation (not suited for a fair comparison of learners!)
 #' Map(function(task, resampling) {
-#'    resampling$instantiate(task)
+#'   resampling$instantiate(task)
 #' }, task = grid$task, resampling = grid$resampling)
-#'
 #' \dontrun{
 #' benchmark(grid)
 #' }

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -15,15 +15,15 @@ bibentries = c(
 
   bischl_2012 = bibentry("article",
     title = "Resampling Methods for Meta-Model Validation with Recommendations for Evolutionary Computation",
-    author       = "Bernd Bischl and Olaf Mersmann and Heike Trautmann and Claus Weihs",
-    year         = "2012",
-    month        = "jun",
-    journal      = "Evolutionary Computation",
-    publisher    = "MIT Press - Journals",
-    volume       = "20",
-    number       = "2",
-    pages        = "249--275",
-    doi          = "10.1162/evco_a_00069"
+    author = "Bernd Bischl and Olaf Mersmann and Heike Trautmann and Claus Weihs",
+    year = "2012",
+    month = "jun",
+    journal = "Evolutionary Computation",
+    publisher = "MIT Press - Journals",
+    volume = "20",
+    number = "2",
+    pages = "249--275",
+    doi = "10.1162/evco_a_00069"
   ),
 
   breiman_1984 = bibentry("book",

--- a/R/default_measures.R
+++ b/R/default_measures.R
@@ -17,8 +17,9 @@
 #' default_measures("classif")
 #' default_measures("regr")
 default_measures = function(task_type) {
-  if (is.null(task_type))
+  if (is.null(task_type)) {
     return(list())
+  }
   assert_choice(task_type, names(mlr_reflections$default_measures))
   keys = mlr_reflections$default_measures[[task_type]]
   mlr_measures$mget(keys)

--- a/R/mlr_resamplings.R
+++ b/R/mlr_resamplings.R
@@ -39,8 +39,9 @@ as.data.table.DictionaryResampling = function(x, ...) { # nolint
   setkeyv(map_dtr(x$keys(), function(key) {
     r = tryCatch(x$get(key),
       missingDefaultError = function(e) NULL)
-    if (is.null(r))
+    if (is.null(r)) {
       return(list(key = key))
+    }
 
     list(key = key, params = list(r$param_set$ids()), iters = r$iters)
   }, .fill = TRUE), "key")[]

--- a/R/task_converters.R
+++ b/R/task_converters.R
@@ -40,7 +40,7 @@ convert_task = function(intask, target = NULL, new_type = NULL, drop_original_ta
 
   # Add the original target(s) as features, only keeping 'new_target'.
   if (!all(intask$target_names == target)) {
-    newtask$set_col_roles(setdiff(intask$col_roles$target, target),  "feature")
+    newtask$set_col_roles(setdiff(intask$col_roles$target, target), "feature")
   }
 
   # during prediction, when target is NA, we do not call droplevels

--- a/R/worker.R
+++ b/R/worker.R
@@ -173,7 +173,7 @@ learner_predict = function(learner, task, row_ids = NULL) {
       miss_ids = is_missing_prediction_data(prediction)
 
       lg$debug("Imputing %i/%i predictions using fallback '%s'",
-        length(miss_ids), length(prediction$row_ids), fb$id,  learner = fb$clone())
+        length(miss_ids), length(prediction$row_ids), fb$id, learner = fb$clone())
 
       if (length(miss_ids)) {
         learner$state$log = append_log(learner$state$log, "predict", "output", "Using fallback learner to impute predictions")

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -136,7 +136,7 @@ test_that("predict on newdata works / no target column", {
   learner = lrn("regr.featureless")
   learner$properties = setdiff(learner$properties, "missings")
   learner$train(task)
-  learner$predict_newdata(xdt[,1])
+  learner$predict_newdata(xdt[, 1])
 })
 
 
@@ -181,7 +181,7 @@ test_that("predict train + test set", {
 })
 
 test_that("assertions work (#357)", {
-  measures = lapply(c("classif.auc","classif.acc"), msr)
+  measures = lapply(c("classif.auc", "classif.acc"), msr)
   task = tsk("iris")
   lrn = lrn("classif.featureless")
   p = lrn$train(task)$predict(task)

--- a/tests/testthat/test_PredictionClassif.R
+++ b/tests/testthat/test_PredictionClassif.R
@@ -25,7 +25,7 @@ test_that("setting threshold binaryclass", {
   expect_equal(as.character(p$response), colnames(p$prob)[max.col(p$prob)])
 
   response_before = p$response
-  expect_false(withVisible(p$set_threshold(0.5))$visible) #356
+  expect_false(withVisible(p$set_threshold(0.5))$visible) # 356
   expect_factor(p$response, levels = task$class_names, any.missing = FALSE)
   expect_equal(p$response, response_before)
   expect_lt(p$score(msr("classif.ce")), 0.25)

--- a/tests/testthat/test_PredictionDataClassif.R
+++ b/tests/testthat/test_PredictionDataClassif.R
@@ -17,6 +17,6 @@ test_that("PredictionDataClassif", {
 
 test_that("row sums of prob sums up to 1 ", {
   pdata = new_prediction_data(list(row_ids = 1:2, truth = factor(c("a", "b")),
-      response = c("a", "b"), prob = matrix(c(0.5, 0.5, 0.5, 1), 2)), "classif")
+    response = c("a", "b"), prob = matrix(c(0.5, 0.5, 0.5, 1), 2)), "classif")
   expect_error(check_prediction_data(pdata), "sum up")
 })

--- a/tests/testthat/test_Resampling.R
+++ b/tests/testthat/test_Resampling.R
@@ -67,8 +67,9 @@ test_that("cloning", {
 
     clone = r$clone(deep = TRUE)
     expect_different_address(r$param_set, clone$param_set)
-    if (is.data.table(r$instance))
+    if (is.data.table(r$instance)) {
       expect_different_address(r$instance, clone$instance)
+    }
   }
 })
 

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -246,7 +246,9 @@ test_that("groups/weights work", {
   task$col_roles$group = character()
   expect_true("groups" %nin% task$properties)
 
-  expect_error({task$col_roles$weight = c("w", "g")}, "up to one")
+  expect_error({
+    task$col_roles$weight = c("w", "g")
+  }, "up to one")
 })
 
 test_that("ordered factors (#95)", {
@@ -314,8 +316,12 @@ test_that("switch columns on and off (#301)", {
 test_that("row roles setters", {
   task = tsk("iris")
 
-  expect_error({ task$row_roles$use = "foo" })
-  expect_error({ task$row_roles$foo = 1L })
+  expect_error({
+    task$row_roles$use = "foo"
+  })
+  expect_error({
+    task$row_roles$foo = 1L
+  })
 
   task$row_roles$use = 1:20
   expect_equal(task$nrow, 20L)
@@ -324,7 +330,9 @@ test_that("row roles setters", {
 test_that("col roles getters/setters", {
   task = tsk("iris")
 
-  expect_error({ task$col_roles$feature = "foo" })
+  expect_error({
+    task$col_roles$feature = "foo"
+  })
 
   # additional roles allowed (#558)
   task$col_roles$foo = "Species"
@@ -401,7 +409,7 @@ test_that("column labels", {
   labels = c("pl", "pw", "sl", "sw", "species")
   task$col_info$label = c(NA, labels)
 
-  task$rbind(iris[1,, drop = FALSE])
+  task$rbind(iris[1, , drop = FALSE])
   expect_names(na.omit(task$col_info$label), permutation.of = labels)
 
   task$cbind(data.frame(foo = 1:151))

--- a/tests/testthat/test_TaskClassif.R
+++ b/tests/testthat/test_TaskClassif.R
@@ -107,8 +107,8 @@ test_that("droplevels keeps level order", {
 
 test_that("target is encoded as factor (#629)", {
   dt = data.table(a = c(1, 2, 3, 4), target = c(1, 1, 0, 1))
-  expect_error(TaskClassif$new(id="XX", backend = dt, target = "target"), "factor")
+  expect_error(TaskClassif$new(id = "XX", backend = dt, target = "target"), "factor")
 
   dt$target = ordered(dt$target)
-  TaskClassif$new(id="XX", backend = dt, target = "target")
+  TaskClassif$new(id = "XX", backend = dt, target = "target")
 })

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -256,7 +256,7 @@ test_that("parallelization works", {
 
   grid = benchmark_grid(list(tsk("wine"), tsk("sonar")), replicate(2, lrn("classif.debug")), rsmp("cv", folds = 2))
   njobs = 3L
-  bmr = with_future(future::multisession,  {
+  bmr = with_future(future::multisession, {
     benchmark(grid, store_models = TRUE)
   }, workers = njobs)
 

--- a/tests/testthat/test_convert_task.R
+++ b/tests/testthat/test_convert_task.R
@@ -8,12 +8,14 @@ test_that("convert_task - Regr -> Regr", {
   expect_true(all(result$feature_names != "age"))
   expect_true(all(result$feature_names != "medv"))
   expect_true(all(unlist(imap(result$row_roles,
-          .f = function(z, x) {all(result$row_roles[[x]] == task$row_roles[[x]])}))
-      ))
+    .f = function(z, x) {
+      all(result$row_roles[[x]] == task$row_roles[[x]])
+    }
+  ))))
   expect_true(
     all(map_lgl(c("weights", "groups", "strata", "nrow"), function(x) {
-        all(result[[x]] == task[[x]])
-  })))
+      all(result[[x]] == task[[x]])
+    })))
 })
 
 test_that("convert_task - Regr -> Classif", {
@@ -26,12 +28,14 @@ test_that("convert_task - Regr -> Classif", {
   expect_true(all(result$feature_names != "chas"))
   expect_true(all(result$feature_names != "medv"))
   expect_true(all(unlist(imap(result$row_roles,
-    .f = function(z, x) {all(result$row_roles[[x]] == task$row_roles[[x]])}))
-  ))
+    .f = function(z, x) {
+      all(result$row_roles[[x]] == task$row_roles[[x]])
+    }
+  ))))
   expect_true(
     all(map_lgl(c("weights", "groups", "strata", "nrow"), function(x) {
       all(result[[x]] == task[[x]])
-  })))
+    })))
 })
 
 test_that("convert_task - Classif -> Regr", {
@@ -44,12 +48,14 @@ test_that("convert_task - Classif -> Regr", {
   expect_true(all(result$feature_names != "Sepal.Width"))
   expect_true(all(result$feature_names != "Species"))
   expect_true(all(unlist(imap(result$row_roles,
-    .f = function(z, x) {all(result$row_roles[[x]] == task$row_roles[[x]])}))
-  ))
+    .f = function(z, x) {
+      all(result$row_roles[[x]] == task$row_roles[[x]])
+    }
+  ))))
   expect_true(
     all(map_lgl(c("weights", "groups", "strata", "nrow"), function(x) {
       all(result[[x]] == task[[x]])
-  })))
+    })))
 })
 
 test_that("convert_task - same target", {
@@ -66,13 +72,17 @@ test_that("convert_task - same target", {
     expect_task(result)
     expect_true(result$col_roles$target == "medv")
     expect_true(all(unlist(imap(result$row_roles,
-      .f = function(z, x) {all(result$row_roles[[x]] == task$row_roles[[x]])}))
-    ))
+      .f = function(z, x) {
+        all(result$row_roles[[x]] == task$row_roles[[x]])
+      }
+    ))))
     expect_true(
       all(map_lgl(
         c("weights", "groups", "strata", "nrow", "ncol", "feature_names", "target_names",
           "task_type"),
-        function(x) {all(result[[x]] == task[[x]])}
+        function(x) {
+          all(result[[x]] == task[[x]])
+        }
     )))
   }
 })

--- a/tests/testthat/test_hashes.R
+++ b/tests/testthat/test_hashes.R
@@ -4,8 +4,9 @@ expect_hash_changes = function(x) {
 
   x$id = "foo"
   expect_false(identical(x$id, id_before))
-  if (!is.na(hash_before))
+  if (!is.na(hash_before)) {
     expect_false(identical(x$hash, hash_before))
+  }
   x$id = id_before
   expect_true(identical(x$id, id_before))
   expect_true(identical(x$hash, hash_before))
@@ -28,5 +29,5 @@ test_that("measure$hash", {
 
 test_that("resampling$hash", {
   x = rsmp("cv")
-    expect_hash_changes(x)
+  expect_hash_changes(x)
 })


### PR DESCRIPTION
This is a first diff of the new {[mlr.styler](https://github.com/mlr-org/styler.mlr)} package (still private) by @lorenzwalthert.
Lorenz put a [lot of time](https://github.com/mlr-org/styler.mlr/pull/1) into our mlr-style, not only by creating this new package but also in the past.

It should make updating + maintenance more easy and should also serve as an exemplary package for additional styles next to the `tidyverse_style`.
Beforehand we used a [fork of mine](https://github.com/pat-s/styler/tree/mlr-style).

@mllg I am not sure if you use {styler} in practice for {mlr3} but your input on specific re-occurring patterns which are changed in the diff is appreciated.
Remember that we can create the style guide to be passive/non-invasive so that in some cases multiple solutions are allowed / not force styled.

Some years have passed since we evaluated the initial guide. If some of your coding patterns have changed since there, it would now be a good time to discuss these here.

Also cc @berndbischl @mb706 @be-marc @pfistfl @jakob-r @RaphaelS1 (your input is appreciated/desired as well of course as the style applies to all mlr-org repos. {mlr3} is just the demo-repo for now.).


@lorenzwalthert
If there are any new transformers that you know of which would be possibly helpful here, just suggest them :)