### PR TITLE
fix predict newdata

### DIFF
--- a/R/Learner.R
+++ b/R/Learner.R
@@ -236,7 +236,7 @@ Learner = R6Class("Learner",
     #' @return [Prediction].
     predict = function(task, row_ids = NULL) {
       task = assert_task(as_task(task))
-      assert_learnable(task, self)
+      assert_predictable(task, self)
       row_ids = assert_row_ids(row_ids, null.ok = TRUE)
 
       if (is.null(self$state$model) && is.null(self$state$fallback_state$model)) {

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -129,6 +129,14 @@ test_that("predict on newdata works / no target column", {
 
   expect_data_table(as.data.table(p), nrows = length(test))
   expect_set_equal(as.data.table(p)$row_ids, seq_along(test))
+
+  # newdata with 1 col and learner that does not support missings
+  xdt = data.table(x = 1, y = 1)
+  task = as_task_regr(xdt, target = "y")
+  learner = lrn("regr.featureless")
+  learner$properties = setdiff(learner$properties, "missings")
+  learner$train(task)
+  learner$predict_newdata(xdt[,1])
 })
 
 


### PR DESCRIPTION
What failed?
- `$predict_newdata` without y column for a learner that does not support missings

https://github.com/mlr-org/mlr3/blob/893611d497b2299765ccc338d8f16f6108caf85d/tests/testthat/test_Learner.R#L134-L139

Why?
- We called `assert_learnable()` (questionable name here) when calling `$predict` which checked ALL columns if there are missings.

Note: Another fix would be to just change `miss = task$missings()` to `miss = task$missings(cols = task$feature_names)` but then we still have the weird naming of `assert_learnable()` for prediction. Also we probably never ever want to allow missing y in `train()`?