### PR TITLE
Update `ResamplingCustomCV` and add tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Imports:
     lgr (>= 0.3.4),
     mlbench,
     mlr3measures (>= 0.3.0),
-    mlr3misc (>= 0.9.0),
+    mlr3misc (>= 0.9.2),
     parallelly,
     palmerpenguins,
     paradox (>= 0.6.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,7 +87,7 @@ Suggests:
     testthat (>= 3.0.0)
 Encoding: UTF-8
 Config/testthat/edition: 3
-Config/testthat/parallel: true
+Config/testthat/parallel: false
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.1.1

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -26,8 +26,8 @@
 #'
 #' # Instantiate Resampling:
 #' custom_cv = rsmp("custom_cv")
-#' split_f = factor(c(rep(letters[1:3], each = 3), NA))
-#' custom_cv$instantiate(task, split = split_f)
+#' f = factor(c(rep(letters[1:3], each = 3), NA))
+#' custom_cv$instantiate(task, f = split_f)
 #' custom_cv$iters # 3 folds
 #'
 #' # Individual sets:

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -66,7 +66,7 @@ ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = Resampling,
         type = NULL
         assert_character(split, len = 1)
         assert_subset(split, task$feature_types[`type` == "factor" | `type` == "character", ]$id)
-        split = as.factor(task$data()[[split]])
+        split = as.factor(task$data(cols = split))
       }
       self$instance = split(task$row_ids, split, drop = TRUE)
       self$task_hash = task$hash

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -4,15 +4,14 @@
 #' @include Resampling.R
 #'
 #' @description
-#' Splits data into training and test sets in a cross-validation fashion.
-#' Splits are defined by argument `split` provided during instantiation.
+#' Splits data into training and test sets in a cross-validation fashion based
+#' on a user-provided categorical vector.
+#' This vector can be passed during instantiation either via an arbitrary factor `f`
+#' with the same length as `task$nrow`, or via a single string `col` referring to a
+#' column in the task.
 #'
-#' `split` can either be an external factor vector with the same length as
-#' `task$nrow` or a character vector specifying a feature within the task which will be
-#' used for splitting.
-#'
-#' An alternative approach using leave-one-out is showcased in the examples of
-#' [mlr_resamplings_loo].
+#' An alternative but equivalent approach using leave-one-out resampling is
+#' showcased in the examples of [mlr_resamplings_loo].
 #'
 #' @templateVar id custom_cv
 #' @template section_dictionary_resampling

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -27,7 +27,7 @@
 #' # Instantiate Resampling:
 #' custom_cv = rsmp("custom_cv")
 #' f = factor(c(rep(letters[1:3], each = 3), NA))
-#' custom_cv$instantiate(task, f = split_f)
+#' custom_cv$instantiate(task, f = f)
 #' custom_cv$iters # 3 folds
 #'
 #' # Individual sets:

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -66,7 +66,8 @@ ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = Resampling,
         type = NULL
         assert_character(split, len = 1)
         assert_subset(split, task$feature_types[`type` == "factor" | `type` == "character", ]$id)
-        split = as.factor(task$data(cols = split))
+        browser()
+        split = as.factor(task$data(cols = split)[[split]])
       }
       self$instance = split(task$row_ids, split, drop = TRUE)
       self$task_hash = task$hash

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -5,7 +5,11 @@
 #'
 #' @description
 #' Splits data into training and test sets in a cross-validation fashion.
-#' Splits are defined by the factor `f` provided during instantiation.
+#' Splits are defined by argument `split` provided during instantiation.
+#'
+#' `split` can either be an external factor vector with the same length as
+#' `task$nrow` or a character vector specifying a feature within the task which will be
+#' used for splitting.
 #'
 #' An alternative approach using leave-one-out is showcased in the examples of
 #' [mlr_resamplings_loo].
@@ -47,6 +51,9 @@ ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = Resampling,
     #'   Used to extract row ids.
     #'
     #' @param split (`factor()`)\cr
+    #'    Either an external factor vector with the same length as
+    #'   `task$nrow` or a character vector specifying a feature within the task which will be
+    #'   used for splitting.
     #'   Row ids are split on this factor, each factor level results in a fold.
     #'   Empty factor levels are dropped and row ids corresponding to missing values are removed,
     #'   c.f. [split()].
@@ -57,6 +64,7 @@ ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = Resampling,
       } else if (is.character(split)) {
         # suppress "no visible binding for global variable" note
         type = NULL
+        assert_character(split, len = 1)
         assert_subset(split, task$feature_types[`type` == "factor" | `type` == "character", ]$id)
         split = as.factor(task$data()[[split]])
       }

--- a/R/helper.R
+++ b/R/helper.R
@@ -49,8 +49,8 @@ allow_partial_matching = list(
 # extract values from a single column of a data table
 # tries to avoid the overhead of data.table for small tables
 fget = function(tab, i, j, key) {
-  if (nrow(tab) < 1000L) {
-    tab[list(i), j, on = key, with = FALSE][[1L]]
+  if (nrow(tab) > 1000L) {
+    tab[list(i), j, on = key, with = FALSE, nomatch = NULL][[1L]]
   } else {
     x = tab[[key]]
     if (is.character(x) && is.character(i)) {

--- a/R/helper.R
+++ b/R/helper.R
@@ -49,7 +49,7 @@ allow_partial_matching = list(
 # extract values from a single column of a data table
 # tries to avoid the overhead of data.table for small tables
 fget = function(tab, i, j, key) {
-  if (task$nrow < 1000L) {
+  if (nrow(tab) < 1000L) {
     tab[list(i), j, on = key, with = FALSE][[1L]]
   } else {
     x = tab[[key]]

--- a/R/helper.R
+++ b/R/helper.R
@@ -49,14 +49,14 @@ allow_partial_matching = list(
 # extract values from a single column of a data table
 # tries to avoid the overhead of data.table for small tables
 fget = function(tab, i, j, key) {
-  if (nrow(tab) > 1000L) {
+  if (task$nrow < 1000L) {
     tab[list(i), j, on = key, with = FALSE][[1L]]
   } else {
-    table = tab[[key]]
-    if (is.character(table)) {
-      tab[[j]][chmatch(i, table, nomatch = 0L)]
+    x = tab[[key]]
+    if (is.character(x) && is.character(i)) {
+      tab[[j]][x %chin% i]
     } else {
-      tab[[j]][match(i, table, nomatch = 0L)]
+      tab[[j]][x %in% i]
     }
   }
 }

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -25,8 +25,8 @@ task$filter(1:10)
 
 # Instantiate Resampling:
 custom_cv = rsmp("custom_cv")
-f = factor(c(rep(letters[1:3], each = 3), NA))
-custom_cv$instantiate(task, f)
+split_f = factor(c(rep(letters[1:3], each = 3), NA))
+custom_cv$instantiate(task, split = split_f)
 custom_cv$iters # 3 folds
 
 # Individual sets:
@@ -104,7 +104,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Method \code{instantiate()}}{
 Instantiate this \link{Resampling} as cross validation with custom splits.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ResamplingCustomCV$instantiate(task, f)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ResamplingCustomCV$instantiate(task, split)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -113,7 +113,7 @@ Instantiate this \link{Resampling} as cross validation with custom splits.
 \item{\code{task}}{\link{Task}\cr
 Used to extract row ids.}
 
-\item{\code{f}}{(\code{factor()})\cr
+\item{\code{split}}{(\code{factor()})\cr
 Row ids are split on this factor, each factor level results in a fold.
 Empty factor levels are dropped and row ids corresponding to missing values are removed,
 c.f. \code{\link[=split]{split()}}.}

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -30,7 +30,7 @@ task$filter(1:10)
 # Instantiate Resampling:
 custom_cv = rsmp("custom_cv")
 f = factor(c(rep(letters[1:3], each = 3), NA))
-custom_cv$instantiate(task, f = split_f)
+custom_cv$instantiate(task, f = f)
 custom_cv$iters # 3 folds
 
 # Individual sets:

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -29,8 +29,8 @@ task$filter(1:10)
 
 # Instantiate Resampling:
 custom_cv = rsmp("custom_cv")
-split_f = factor(c(rep(letters[1:3], each = 3), NA))
-custom_cv$instantiate(task, split = split_f)
+f = factor(c(rep(letters[1:3], each = 3), NA))
+custom_cv$instantiate(task, f = split_f)
 custom_cv$iters # 3 folds
 
 # Individual sets:

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -6,7 +6,11 @@
 \title{Custom Cross Validation}
 \description{
 Splits data into training and test sets in a cross-validation fashion.
-Splits are defined by the factor \code{f} provided during instantiation.
+Splits are defined by argument \code{split} provided during instantiation.
+
+\code{split} can either be an external factor vector with the same length as
+\code{task$nrow} or a character vector specifying a feature within the task which will be
+used for splitting.
 
 An alternative approach using leave-one-out is showcased in the examples of
 \link{mlr_resamplings_loo}.
@@ -114,6 +118,9 @@ Instantiate this \link{Resampling} as cross validation with custom splits.
 Used to extract row ids.}
 
 \item{\code{split}}{(\code{factor()})\cr
+Either an external factor vector with the same length as
+\code{task$nrow} or a character vector specifying a feature within the task which will be
+used for splitting.
 Row ids are split on this factor, each factor level results in a fold.
 Empty factor levels are dropped and row ids corresponding to missing values are removed,
 c.f. \code{\link[=split]{split()}}.}

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -108,7 +108,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Method \code{instantiate()}}{
 Instantiate this \link{Resampling} as cross validation with custom splits.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ResamplingCustomCV$instantiate(task, split)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ResamplingCustomCV$instantiate(task, f = NULL, col = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -117,13 +117,16 @@ Instantiate this \link{Resampling} as cross validation with custom splits.
 \item{\code{task}}{\link{Task}\cr
 Used to extract row ids.}
 
-\item{\code{split}}{(\code{factor()} | \code{character(1)})\cr
-Either an external factor vector with the same length as
-\code{task$nrow}, or a single column of the task which will be
-used for splitting.
-Row ids are split on this factor, each factor level results in a fold.
+\item{\code{f}}{(\code{factor()} | \code{character()})\cr
+Vector of type factor or character with the same length as \code{task$nrow}.
+Row ids are split on this vector, each distinct value results in a fold.
 Empty factor levels are dropped and row ids corresponding to missing values are removed,
 c.f. \code{\link[=split]{split()}}.}
+
+\item{\code{col}}{(\code{character(1)})\cr
+Name of the task column to use for splitting.
+Alternative and mutually exclusive to providing the factor levels as a vector via
+parameter \code{f}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -5,15 +5,14 @@
 \alias{ResamplingCustomCV}
 \title{Custom Cross Validation}
 \description{
-Splits data into training and test sets in a cross-validation fashion.
-Splits are defined by argument \code{split} provided during instantiation.
+Splits data into training and test sets in a cross-validation fashion based
+on a user-provided categorical vector.
+This vector can be passed during instantiation either via an arbitrary factor \code{f}
+with the same length as \code{task$nrow}, or via a single string \code{col} referring to a
+column in the task.
 
-\code{split} can either be an external factor vector with the same length as
-\code{task$nrow} or a character vector specifying a feature within the task which will be
-used for splitting.
-
-An alternative approach using leave-one-out is showcased in the examples of
-\link{mlr_resamplings_loo}.
+An alternative but equivalent approach using leave-one-out resampling is
+showcased in the examples of \link{mlr_resamplings_loo}.
 }
 \section{Dictionary}{
 

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -117,9 +117,9 @@ Instantiate this \link{Resampling} as cross validation with custom splits.
 \item{\code{task}}{\link{Task}\cr
 Used to extract row ids.}
 
-\item{\code{split}}{(\code{factor()})\cr
+\item{\code{split}}{(\code{factor()} | \code{character(1)})\cr
 Either an external factor vector with the same length as
-\code{task$nrow} or a character vector specifying a feature within the task which will be
+\code{task$nrow}, or a single column of the task which will be
 used for splitting.
 Row ids are split on this factor, each factor level results in a fold.
 Empty factor levels are dropped and row ids corresponding to missing values are removed,

--- a/tests/testthat/test_Resampling.R
+++ b/tests/testthat/test_Resampling.R
@@ -122,28 +122,31 @@ test_that("Evaluation on validation set", {
 
 test_that("custom_cv", {
   task = tsk("penguins")
-  r = rsmp("custom_cv")
+  ccv = rsmp("custom_cv")
+
   f = task$data(cols = "island")[[1L]]
-  r$instantiate(task, f)
-  expect_resampling(r, task = task)
+  ccv$instantiate(task, f = f)
+  expect_resampling(ccv, task = task)
+  expect_equal(ccv$iters, 3L)
+  expect_list(ccv$instance, "integer", len = 3)
+  expect_names(names(ccv$instance), permutation.of = levels(f))
 
-  expect_equal(r$iters, 3L)
-  expect_list(r$instance, "integer", len = 3)
-  expect_names(names(r$instance), permutation.of = levels(f))
+  ccv$instantiate(task, col = "island")
+  expect_resampling(ccv, task = task)
+  expect_equal(ccv$iters, 3L)
+  expect_list(ccv$instance, "integer", len = 3)
+  names(ccv$instance)
+  expect_names(names(ccv$instance), permutation.of = levels(f))
 
-
-  task = tsk("penguins")
-  task$filter(1:10)
-  r = rsmp("custom_cv")
+  task = task$clone(TRUE)$filter(1:10)
   f = factor(rep(letters[1:3], each = 3))
-  expect_error(r$instantiate(task, f), "length")
-
+  expect_error(ccv$instantiate(task, f), "length")
   f[10] = NA
-  r$instantiate(task, f)
-  expect_data_table(as.data.table(r), nrows = 3L * 9L)
+  ccv$instantiate(task, f)
+  expect_data_table(as.data.table(ccv), nrows = 3L * 9L)
 
   f[] = NA
-  expect_error(r$instantiate(task, f), "only missing")
+  expect_error(ccv$instantiate(task, f), "only missing")
 })
 
 test_that("loo with groups", {

--- a/tests/testthat/test_mlr_resampling_custom.R
+++ b/tests/testthat/test_mlr_resampling_custom.R
@@ -6,30 +6,30 @@ test_that("custom has duplicated ids", {
 test_that("custom_cv accepts external factor", {
   task = tsk("penguins")
   task$filter(1:10)
-  r = rsmp("custom_cv")
+
+  ccv = rsmp("custom_cv")
   split_f = factor(c(rep(letters[1:3], each = 3), NA))
-  r$instantiate(task, split = split_f)
+  ccv$instantiate(task, f = split_f)
 
-  expect_class(r$instance, "list")
-  expect_length(r$instance, 3)
-  expect_length(r$train_set(3), 6)
+  expect_class(ccv$instance, "list")
+  expect_length(ccv$instance, 3)
+  expect_length(ccv$train_set(3), 6)
 
-  expect_identical(r$duplicated_ids, FALSE)
-
+  expect_identical(ccv$duplicated_ids, FALSE)
 })
 
 test_that("custom_cv accepts task feature", {
   task = tsk("german_credit")
-  r = rsmp("custom_cv")
-  expect_identical(r$duplicated_ids, FALSE)
+  ccv = rsmp("custom_cv")
+  expect_identical(ccv$duplicated_ids, FALSE)
 
-  r$instantiate(task, split = task$data(cols = "job")[[1L]])
-  expect_class(r$instance, "list")
-  expect_length(r$instance, 4)
-  expect_length(r$train_set(3), 370)
+  ccv$instantiate(task, f = task$data(cols = "job")[[1L]])
+  expect_class(ccv$instance, "list")
+  expect_length(ccv$instance, 4)
+  expect_length(ccv$train_set(3), 370)
 
-  r$instantiate(task, split = "job")
-  expect_class(r$instance, "list")
-  expect_length(r$instance, 4)
-  expect_length(r$train_set(3), 370)
+  ccv$instantiate(task, col = "job")
+  expect_class(ccv$instance, "list")
+  expect_length(ccv$instance, 4)
+  expect_length(ccv$train_set(3), 370)
 })

--- a/tests/testthat/test_mlr_resampling_custom.R
+++ b/tests/testthat/test_mlr_resampling_custom.R
@@ -2,3 +2,31 @@ test_that("custom has duplicated ids", {
   r = rsmp("custom")
   expect_identical(r$duplicated_ids, TRUE)
 })
+
+test_that("custom_cv accepts external factor", {
+  task = tsk("penguins")
+  task$filter(1:10)
+  r = rsmp("custom_cv")
+  split_f = factor(c(rep(letters[1:3], each = 3), NA))
+  r$instantiate(task, split = split_f)
+
+  expect_class(r$instance, "list")
+  expect_length(r$instance, 3)
+  expect_length(r$train_set(3), 6)
+
+  expect_identical(r$duplicated_ids, FALSE)
+
+})
+
+test_that("custom_cv accepts task feature", {
+  task = tsk("german_credit")
+  r = rsmp("custom_cv")
+  r$instantiate(task, split = "job")
+
+  expect_class(r$instance, "list")
+  expect_length(r$instance, 4)
+  expect_length(r$train_set(3), 370)
+
+  expect_identical(r$duplicated_ids, FALSE)
+
+})

--- a/tests/testthat/test_mlr_resampling_custom.R
+++ b/tests/testthat/test_mlr_resampling_custom.R
@@ -21,12 +21,15 @@ test_that("custom_cv accepts external factor", {
 test_that("custom_cv accepts task feature", {
   task = tsk("german_credit")
   r = rsmp("custom_cv")
-  r$instantiate(task, split = "job")
+  expect_identical(r$duplicated_ids, FALSE)
 
+  r$instantiate(task, split = task$data(cols = "job")[[1L]])
   expect_class(r$instance, "list")
   expect_length(r$instance, 4)
   expect_length(r$train_set(3), 370)
 
-  expect_identical(r$duplicated_ids, FALSE)
-
+  r$instantiate(task, split = "job")
+  expect_class(r$instance, "list")
+  expect_length(r$instance, 4)
+  expect_length(r$train_set(3), 370)
 })

--- a/tests/testthat/test_mlr_tasks.R
+++ b/tests/testthat/test_mlr_tasks.R
@@ -18,3 +18,12 @@ test_that("load_x", {
     expect_task_supervised(fun())
   }
 })
+
+test_that("tasks are cloned", {
+  if (packageVersion("mlr3misc") >= "0.9.2") {
+    task = tsk("iris")
+    mlr_tasks$add("foo", task)
+    expect_different_address(task, tsk("foo"))
+    mlr_tasks$remove("foo")
+  }
+})


### PR DESCRIPTION
#651 

@mllg I've found `custom_cv$instantiate(task, split = split_f)` nicer to read than `custom_cv$instantiate(task, f = split_f)`. Feel free to change back if you disagree.

`ResamplingCustomCV` now accepts either an external factor or a feature from the task.