### PR TITLE
Update `run_paramtest()`

### DIFF
--- a/inst/testthat/helper_autotest.R
+++ b/inst/testthat/helper_autotest.R
@@ -413,7 +413,6 @@ run_paramtest = function(learner, fun, exclude = character(), tag = NULL) {
   if (checkmate::test_list(fun)) {
     # for xgboost we pass a character vector with info scraped from the web
     if (any(mlr3misc::map_lgl(fun, function(x) class(x) == "character"))) {
-      browser()
       which = which(mlr3misc::map_lgl(fun, function(x) class(x) == "character"))
       par_package = fun[[which]]
       fun[[which]] = NULL


### PR DESCRIPTION
Allows to pass a list to `fun` which consists of function definitions and character vectors.

This is needed because we scrape the xgboost params from their website and store the results in a character vector which we need to pass to `run_paramtest()`.

Required for https://github.com/mlr-org/mlr3learners/pull/213.