### PR TITLE
clone hotstart learner

### DIFF
--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -124,6 +124,7 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
     hotstart_grid = pmap_dtr(grid, function(task, learner, resampling, iteration, ...) {
       if (!is.null(learner$hotstart_stack)) {
         # search for hotstart learner
+        learner = learner$clone()
         task_hashes = task_hashes(task, resampling)
         start_learner = get_private(learner$hotstart_stack)$.start_learner(learner, task_hashes[iteration])
       }


### PR DESCRIPTION
The learners in `benchmark()` must be cloned for each resampling iteration when hotstarting. We only clone per experiment. Test data is leaked into the hotstarted models. We should fix this soon.

The unit test should probably go into mlr3learners because of the `xgboost` dependency.

```r
task = tsk("pima")
learner_1 = lrn("classif.xgboost", nrounds = 100, predict_type = "prob")
resampling = rsmp("cv", folds = 3)
resampling$instantiate(task)

rr = resample(task, learner_1, resampling, store_models = TRUE)

stack = HotstartStack$new(rr$learners)
learner_2 = lrn("classif.xgboost", nrounds = 200, predict_type = "prob", hotstart_stack = stack)

bmr_1 = benchmark(benchmark_grid(task, learner_2, resampling))
bmr_2 = benchmark(benchmark_grid(task, learner_2, resampling), allow_hotstart = TRUE)

expect_set_equal(bmr_1$score(msr("classif.auc"))$classif.auc, bmr_2$score(msr("classif.auc"))$classif.auc)
```


