### PR TITLE
fix inf check in task construction

### DIFF
--- a/R/as_task_classif.R
+++ b/R/as_task_classif.R
@@ -35,7 +35,7 @@ as_task_classif.TaskClassif = function(x, clone = FALSE, ...) { # nolint
 #'   Level of the positive class. See [TaskClassif].
 #' @export
 as_task_classif.data.frame = function(x, target = NULL, id = deparse(substitute(x)), positive = NULL, ...) { # nolint
-  ii = which(map_lgl(x[map_lgl(x, is.double)], anyInfinite))
+  ii = which(map_lgl(subset(x, select = map_lgl(x, is.double)), anyInfinite))
   if (length(ii)) {
     warningf("Detected columns with unsupported Inf values in data: %s", str_collapse(names(ii)))
   }

--- a/R/as_task_regr.R
+++ b/R/as_task_regr.R
@@ -33,7 +33,7 @@ as_task_regr.TaskRegr = function(x, clone = FALSE, ...) { # nolint
 #'   Defaults to the (deparsed and substituted) name of `x`.
 #' @export
 as_task_regr.data.frame = function(x, target, id = deparse(substitute(x)), ...) { # nolint
-  ii = which(map_lgl(x[map_lgl(x, is.double)], anyInfinite))
+  ii = which(map_lgl(subset(x, select = map_lgl(x, is.double)), anyInfinite))
   if (length(ii)) {
     warningf("Detected columns with unsupported Inf values in data: %s", str_collapse(names(ii)))
   }


### PR DESCRIPTION
The latest version does not work with `data.table()`.

```r
data = tsk("pima")$data()
as_task_classif(data, target = "diabetes")

Error in `[.data.table`(x, map_lgl(x, is.double)) : 
  i evaluates to a logical vector length 9 but there are 768 rows. Recycling of logical i is no longer allowed as it hides more bugs than is worth the rare convenience. Explicitly use rep(...,length=.N) if you really need to recycle.
```