### PR TITLE
remove obsolete # nolint

### DIFF
--- a/R/install_pkgs.R
+++ b/R/install_pkgs.R
@@ -28,7 +28,7 @@
 #' @export
 #' @examples
 #' extract_pkgs(lrns(c("regr.rpart", "regr.featureless")))
-install_pkgs = function(x, ...) { # nolint
+install_pkgs = function(x, ...) {
   require_namespaces("remotes")
   pkg = NULL
 


### PR DESCRIPTION
Or at least, it looks like this is obsolete (since the assignment_linter is dropped in mlr3's .lintr config)