### PR TITLE
feat: Add method $set() to Learner.

### DIFF
--- a/R/Learner.R
+++ b/R/Learner.R
@@ -351,6 +351,21 @@ Learner = R6Class("Learner",
     },
 
     #' @description
+    #' Sets parameters of the learner. Existing parameters are overwritten if their values are
+    #' changed. Other parameters are left as is.
+    #' @return
+    #' Returns the object itself, but motified **by reference**.
+    set = function(...) {
+      new_pars = list(...)
+      assert_named(new_pars)
+      old_pars = self$param_set$values
+      old_pars = old_pars[names(old_pars) %nin% names(new_pars)]
+      pars = c(new_pars, old_pars)
+      self$param_set$values = pars
+      invisible(self)
+    },
+
+    #' @description
     #' Extracts the base learner from nested learner objects like
     #' `GraphLearner` in \CRANpkg{mlr3pipelines} or `AutoTuner` in
     #' \CRANpkg{mlr3tuning}.


### PR DESCRIPTION
This makes the setting of parameters more convenient than
it used to be.

Example: 

``` r
library("mlr3")
l = lrn("regr.rpart")
l$param_set$values
#> $xval
#> [1] 0
l$set(xval = 2, minsplit = 3)
l$param_set$values
#> $xval
#> [1] 2
#> 
#> $minsplit
#> [1] 3
```

<sup>Created on 2022-04-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>