### PR TITLE
refactor: additional task types in mlr_reflections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3
 Title: Machine Learning in R - Next Generation
-Version: 0.13.4
+Version: 0.13.4-9000
 Authors@R:
     c(person(given = "Michel",
              family = "Lang",

--- a/R/PredictionData.R
+++ b/R/PredictionData.R
@@ -22,7 +22,7 @@ NULL
 
 new_prediction_data = function(li, task_type = NULL) {
   li = discard(li, is.null)
-  class(li) = sprintf("PredictionData%s", c(capitalize(task_type), ""))
+  class(li) = c(fget(mlr_reflections$task_types, task_type, "prediction_data", "type"), "PredictionData")
   li
 }
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -73,7 +73,8 @@ assert_learner = function(learner, task = NULL, task_type = NULL, properties = c
   assert_class(learner, "Learner", .var.name = .var.name)
 
   task_type = task_type %??% task$task_type
-  if (!is.null(task_type) && fget(mlr_reflections$task_types, task_type, "learner", "type") %nin% class(learner)) {
+  # check on class(learner) does not work with GraphLearner and AutoTuner
+  if (!is.null(task_type) && fget(mlr_reflections$task_types, task_type, "learner", "type") != fget(mlr_reflections$task_types, learner$task_type, "learner", "type")) {
     stopf("Learner '%s' must have task type '%s'", learner$id, task_type)
   }
 
@@ -100,8 +101,8 @@ assert_task_learner = function(task, learner, cols = NULL) {
   if (length(pars) > 0) {
     stopf("%s cannot be trained with TuneToken present in hyperparameter: %s", learner$format(), str_collapse(names(pars)))
   }
-
-  if (fget(mlr_reflections$task_types, task$task_type, "learner", "type") %nin% class(learner)) {
+  # check on class(learner) does not work with GraphLearner and AutoTuner
+  if (fget(mlr_reflections$task_types, task$task_type, "learner", "type") != fget(mlr_reflections$task_types, learner$task_type, "learner", "type")) {
     stopf("Type '%s' of %s does not match type '%s' of %s",
       task$task_type, task$format(), learner$task_type, learner$format())
   }

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -73,7 +73,7 @@ assert_learner = function(learner, task = NULL, task_type = NULL, properties = c
   assert_class(learner, "Learner", .var.name = .var.name)
 
   task_type = task_type %??% task$task_type
-  if (!is.null(task_type) && task_type != learner$task_type) {
+  if (!is.null(task_type) && fget(mlr_reflections$task_types, task_type, "learner", "type") %nin% class(learner)) {
     stopf("Learner '%s' must have task type '%s'", learner$id, task_type)
   }
 
@@ -101,7 +101,7 @@ assert_task_learner = function(task, learner, cols = NULL) {
     stopf("%s cannot be trained with TuneToken present in hyperparameter: %s", learner$format(), str_collapse(names(pars)))
   }
 
-  if (task$task_type != learner$task_type) {
+  if (fget(mlr_reflections$task_types, task$task_type, "learner", "type") %nin% class(learner)) {
     stopf("Type '%s' of %s does not match type '%s' of %s",
       task$task_type, task$format(), learner$task_type, learner$format())
   }
@@ -151,7 +151,7 @@ assert_measure = function(measure, task = NULL, learner = NULL, .var.name = vnam
 
 
   if (!is.null(task)) {
-    if (!is_scalar_na(measure$task_type) && measure$task_type != task$task_type) {
+    if (!is_scalar_na(measure$task_type) && fget(mlr_reflections$task_types, task$task_type, "measure", "type") %nin% class(measure)) {
       stopf("Measure '%s' is not compatible with type '%s' of task '%s'",
         measure$id, task$task_type, task$id)
     }
@@ -310,12 +310,5 @@ assert_row_sums = function(prob) {
         stopf("Probabilities for observation %i do sum up to %f != 1", i, s)
       }
     }
-  }
-}
-
-assert_same_task_type = function(objs) {
-  task_types = unique(map_chr(objs, "task_type"))
-  if (length(task_types) > 1L) {
-    stopf("Multiple task types detected, but mixing types is not supported: %s", str_collapse(task_types))
   }
 }

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -87,7 +87,7 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
   assert_flag(store_backends)
 
   # check for multiple task types
-  if (any(pmap_lgl(list(design$task, design$learner), function(task, learner) fget(mlr_reflections$task_types, task$task_type, "learner", "type") %nin% class(learner)))) {
+  if (any(pmap_lgl(list(design$task, design$learner), function(task, learner) fget(mlr_reflections$task_types, task$task_type, "learner", "type") != fget(mlr_reflections$task_types, learner$task_type, "learner", "type")))) {
     stopf("Multiple task types detected, but mixing types is not supported: %s", str_collapse(unique(map_chr(c(design$task, design$learner), "task_type"))))
   }
 

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -87,7 +87,9 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
   assert_flag(store_backends)
 
   # check for multiple task types
-  assert_same_task_type(c(design$task, design$learner))
+  if (any(pmap_lgl(list(design$task, design$learner), function(task, learner) fget(mlr_reflections$task_types, task$task_type, "learner", "type") %nin% class(learner)))) {
+    stopf("Multiple task types detected, but mixing types is not supported: %s", str_collapse(unique(map_chr(c(design$task, design$learner), "task_type"))))
+  }
 
   # clone inputs
   setDT(design)

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -87,9 +87,15 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
   assert_flag(store_backends)
 
   # check for multiple task types
-  if (any(pmap_lgl(list(design$task, design$learner), function(task, learner) fget(mlr_reflections$task_types, task$task_type, "learner", "type") != fget(mlr_reflections$task_types, learner$task_type, "learner", "type")))) {
-    stopf("Multiple task types detected, but mixing types is not supported: %s", str_collapse(unique(map_chr(c(design$task, design$learner), "task_type"))))
+  task_types = unique(map_chr(design$task, "task_type"))
+  if (length(task_types) > 1) {
+    stopf("Multiple task types detected, but mixing types is not supported: %s", str_collapse(task_types))
   }
+  learner_types = unique(map_chr(design$learner, "task_type"))
+  if (length(learner_types) > 1) {
+    stopf("Multiple learner types detected, but mixing types is not supported: %s", str_collapse(learner_types))
+  }
+  assert_task_learner(design$task[[1]], design$learner[[1]])
 
   # clone inputs
   setDT(design)

--- a/R/mlr_reflections.R
+++ b/R/mlr_reflections.R
@@ -82,9 +82,9 @@ local({
   ### Task
   # task types + constructors
   mlr_reflections$task_types = rowwise_table(.key = "type",
-    ~type,     ~package, ~task,         ~learner,         ~prediction,         ~measure,
-    "regr",    "mlr3",   "TaskRegr",    "LearnerRegr",    "PredictionRegr",    "MeasureRegr",
-    "classif", "mlr3",   "TaskClassif", "LearnerClassif", "PredictionClassif", "MeasureClassif"
+    ~type,     ~package, ~task,         ~learner,         ~prediction,         ~prediction_data,  ~measure,
+    "regr",    "mlr3",   "TaskRegr",    "LearnerRegr",    "PredictionRegr", "PredictionDataRegr",   "MeasureRegr",
+    "classif", "mlr3",   "TaskClassif", "LearnerClassif", "PredictionClassif", "PredictionDataClassif", "MeasureClassif"
   )
 
   mlr_reflections$task_feature_types = c(

--- a/R/mlr_reflections.R
+++ b/R/mlr_reflections.R
@@ -82,8 +82,8 @@ local({
   ### Task
   # task types + constructors
   mlr_reflections$task_types = rowwise_table(.key = "type",
-    ~type,     ~package, ~task,         ~learner,         ~prediction,         ~prediction_data,  ~measure,
-    "regr",    "mlr3",   "TaskRegr",    "LearnerRegr",    "PredictionRegr", "PredictionDataRegr",   "MeasureRegr",
+    ~type,     ~package, ~task,         ~learner,         ~prediction,         ~prediction_data,        ~measure,
+    "regr",    "mlr3",   "TaskRegr",    "LearnerRegr",    "PredictionRegr",    "PredictionDataRegr",    "MeasureRegr",
     "classif", "mlr3",   "TaskClassif", "LearnerClassif", "PredictionClassif", "PredictionDataClassif", "MeasureClassif"
   )
 

--- a/man/mlr_learners_classif.debug.Rd
+++ b/man/mlr_learners_classif.debug.Rd
@@ -48,8 +48,25 @@ lrn("classif.debug")
 }
 
 \section{Parameters}{
-
-, |Id                   |Type      |Default |Levels      |Range                       |, |:--------------------|:---------|:-------|:-----------|:---------------------------|, |error_predict        |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |error_train          |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |message_predict      |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |message_train        |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |predict_missing      |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |predict_missing_type |character |na      |na, omit    |-                           |, |save_tasks           |logical   |FALSE   |TRUE, FALSE |-                           |, |segfault_predict     |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |segfault_train       |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |sleep_train          |untyped   |-       |            |-                           |, |sleep_predict        |untyped   |-       |            |-                           |, |threads              |integer   |-       |            |\eqn{[1, \infty)}{[1, Inf)} |, |warning_predict      |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |warning_train        |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |x                    |numeric   |-       |            |\eqn{[0, 1]}{[0, 1]}        |, |iter                 |integer   |1       |            |\eqn{[1, \infty)}{[1, Inf)} |
+\tabular{lllll}{
+   Id \tab Type \tab Default \tab Levels \tab Range \cr
+   error_predict \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   error_train \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   message_predict \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   message_train \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   predict_missing \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   predict_missing_type \tab character \tab na \tab na, omit \tab - \cr
+   save_tasks \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
+   segfault_predict \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   segfault_train \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   sleep_train \tab untyped \tab - \tab  \tab - \cr
+   sleep_predict \tab untyped \tab - \tab  \tab - \cr
+   threads \tab integer \tab - \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   warning_predict \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   warning_train \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   x \tab numeric \tab - \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   iter \tab integer \tab 1 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_learners_classif.featureless.Rd
+++ b/man/mlr_learners_classif.featureless.Rd
@@ -33,8 +33,10 @@ lrn("classif.featureless")
 }
 
 \section{Parameters}{
-
-, |Id     |Type      |Default |Levels                        |, |:------|:---------|:-------|:-----------------------------|, |method |character |mode    |mode, sample, weighted.sample |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Levels \cr
+   method \tab character \tab mode \tab mode, sample, weighted.sample \cr
+}
 }
 
 \seealso{

--- a/man/mlr_learners_classif.rpart.Rd
+++ b/man/mlr_learners_classif.rpart.Rd
@@ -29,8 +29,19 @@ lrn("classif.rpart")
 }
 
 \section{Parameters}{
-
-, |Id             |Type    |Default |Levels      |Range                       |, |:--------------|:-------|:-------|:-----------|:---------------------------|, |cp             |numeric |0.01    |            |\eqn{[0, 1]}{[0, 1]}        |, |keep_model     |logical |FALSE   |TRUE, FALSE |-                           |, |maxcompete     |integer |4       |            |\eqn{[0, \infty)}{[0, Inf)} |, |maxdepth       |integer |30      |            |\eqn{[1, 30]}{[1, 30]}      |, |maxsurrogate   |integer |5       |            |\eqn{[0, \infty)}{[0, Inf)} |, |minbucket      |integer |-       |            |\eqn{[1, \infty)}{[1, Inf)} |, |minsplit       |integer |20      |            |\eqn{[1, \infty)}{[1, Inf)} |, |surrogatestyle |integer |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |usesurrogate   |integer |2       |            |\eqn{[0, 2]}{[0, 2]}        |, |xval           |integer |10      |            |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{lllll}{
+   Id \tab Type \tab Default \tab Levels \tab Range \cr
+   cp \tab numeric \tab 0.01 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   keep_model \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
+   maxcompete \tab integer \tab 4 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   maxdepth \tab integer \tab 30 \tab  \tab \eqn{[1, 30]}{[1, 30]} \cr
+   maxsurrogate \tab integer \tab 5 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   minbucket \tab integer \tab - \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   minsplit \tab integer \tab 20 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   surrogatestyle \tab integer \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   usesurrogate \tab integer \tab 2 \tab  \tab \eqn{[0, 2]}{[0, 2]} \cr
+   xval \tab integer \tab 10 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \references{

--- a/man/mlr_learners_regr.debug.Rd
+++ b/man/mlr_learners_regr.debug.Rd
@@ -36,8 +36,14 @@ lrn("regr.debug")
 }
 
 \section{Parameters}{
-
-, |Id                   |Type      |Default |Levels      |Range                       |, |:--------------------|:---------|:-------|:-----------|:---------------------------|, |predict_missing      |numeric   |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |predict_missing_type |character |na      |na, omit    |-                           |, |save_tasks           |logical   |FALSE   |TRUE, FALSE |-                           |, |threads              |integer   |-       |            |\eqn{[1, \infty)}{[1, Inf)} |, |x                    |numeric   |-       |            |\eqn{[0, 1]}{[0, 1]}        |
+\tabular{lllll}{
+   Id \tab Type \tab Default \tab Levels \tab Range \cr
+   predict_missing \tab numeric \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   predict_missing_type \tab character \tab na \tab na, omit \tab - \cr
+   save_tasks \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
+   threads \tab integer \tab - \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   x \tab numeric \tab - \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+}
 }
 
 \examples{

--- a/man/mlr_learners_regr.featureless.Rd
+++ b/man/mlr_learners_regr.featureless.Rd
@@ -31,8 +31,10 @@ lrn("regr.featureless")
 }
 
 \section{Parameters}{
-
-, |Id     |Type    |Default |Levels      |, |:------|:-------|:-------|:-----------|, |robust |logical |TRUE    |TRUE, FALSE |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Levels \cr
+   robust \tab logical \tab TRUE \tab TRUE, FALSE \cr
+}
 }
 
 \seealso{

--- a/man/mlr_learners_regr.rpart.Rd
+++ b/man/mlr_learners_regr.rpart.Rd
@@ -28,8 +28,19 @@ lrn("regr.rpart")
 }
 
 \section{Parameters}{
-
-, |Id             |Type    |Default |Levels      |Range                       |, |:--------------|:-------|:-------|:-----------|:---------------------------|, |cp             |numeric |0.01    |            |\eqn{[0, 1]}{[0, 1]}        |, |keep_model     |logical |FALSE   |TRUE, FALSE |-                           |, |maxcompete     |integer |4       |            |\eqn{[0, \infty)}{[0, Inf)} |, |maxdepth       |integer |30      |            |\eqn{[1, 30]}{[1, 30]}      |, |maxsurrogate   |integer |5       |            |\eqn{[0, \infty)}{[0, Inf)} |, |minbucket      |integer |-       |            |\eqn{[1, \infty)}{[1, Inf)} |, |minsplit       |integer |20      |            |\eqn{[1, \infty)}{[1, Inf)} |, |surrogatestyle |integer |0       |            |\eqn{[0, 1]}{[0, 1]}        |, |usesurrogate   |integer |2       |            |\eqn{[0, 2]}{[0, 2]}        |, |xval           |integer |10      |            |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{lllll}{
+   Id \tab Type \tab Default \tab Levels \tab Range \cr
+   cp \tab numeric \tab 0.01 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   keep_model \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
+   maxcompete \tab integer \tab 4 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   maxdepth \tab integer \tab 30 \tab  \tab \eqn{[1, 30]}{[1, 30]} \cr
+   maxsurrogate \tab integer \tab 5 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   minbucket \tab integer \tab - \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   minsplit \tab integer \tab 20 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   surrogatestyle \tab integer \tab 0 \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   usesurrogate \tab integer \tab 2 \tab  \tab \eqn{[0, 2]}{[0, 2]} \cr
+   xval \tab integer \tab 10 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \references{

--- a/man/mlr_measures_aic.Rd
+++ b/man/mlr_measures_aic.Rd
@@ -34,8 +34,10 @@ msr("aic")
 }
 
 \section{Parameters}{
-
-, |Id |Type    |Default |Range                       |, |:--|:-------|:-------|:---------------------------|, |k  |integer |-       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   k \tab integer \tab - \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \seealso{

--- a/man/mlr_measures_classif.costs.Rd
+++ b/man/mlr_measures_classif.costs.Rd
@@ -36,8 +36,10 @@ msr("classif.costs")
 }
 
 \section{Parameters}{
-
-, |Id        |Type    |Default |Levels      |, |:---------|:-------|:-------|:-----------|, |normalize |logical |TRUE    |TRUE, FALSE |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Levels \cr
+   normalize \tab logical \tab TRUE \tab TRUE, FALSE \cr
+}
 }
 
 \examples{

--- a/man/mlr_measures_classif.fbeta.Rd
+++ b/man/mlr_measures_classif.fbeta.Rd
@@ -36,8 +36,10 @@ msr("classif.fbeta")
 }
 
 \section{Parameters}{
-
-, |Id   |Type    |Default |Range                       |, |:----|:-------|:-------|:---------------------------|, |beta |integer |-       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   beta \tab integer \tab - \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \section{Meta Information}{

--- a/man/mlr_measures_debug.Rd
+++ b/man/mlr_measures_debug.Rd
@@ -32,8 +32,10 @@ msr("debug")
 }
 
 \section{Parameters}{
-
-, |Id       |Type    |Default |Range                |, |:--------|:-------|:-------|:--------------------|, |na_ratio |numeric |-       |\eqn{[0, 1]}{[0, 1]} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   na_ratio \tab numeric \tab - \tab \eqn{[0, 1]}{[0, 1]} \cr
+}
 }
 
 \examples{

--- a/man/mlr_measures_selected_features.Rd
+++ b/man/mlr_measures_selected_features.Rd
@@ -35,8 +35,10 @@ msr("selected_features")
 }
 
 \section{Parameters}{
-
-, |Id        |Type    |Default |Levels      |, |:---------|:-------|:-------|:-----------|, |normalize |logical |FALSE   |TRUE, FALSE |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Levels \cr
+   normalize \tab logical \tab FALSE \tab TRUE, FALSE \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_2dnormals.Rd
+++ b/man/mlr_task_generators_2dnormals.Rd
@@ -17,8 +17,12 @@ tgen("2dnormals")
 }
 
 \section{Parameters}{
-
-, |Id |Type    |Default |Range                       |, |:--|:-------|:-------|:---------------------------|, |cl |integer |-       |\eqn{[2, \infty)}{[2, Inf)} |, |r  |numeric |-       |\eqn{[1, \infty)}{[1, Inf)} |, |sd |numeric |-       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   cl \tab integer \tab - \tab \eqn{[2, \infty)}{[2, Inf)} \cr
+   r \tab numeric \tab - \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   sd \tab numeric \tab - \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_cassini.Rd
+++ b/man/mlr_task_generators_cassini.Rd
@@ -17,8 +17,12 @@ tgen("cassini")
 }
 
 \section{Parameters}{
-
-, |Id       |Type    |Default |Range                       |, |:--------|:-------|:-------|:---------------------------|, |relsize1 |integer |2       |\eqn{[1, \infty)}{[1, Inf)} |, |relsize2 |integer |2       |\eqn{[1, \infty)}{[1, Inf)} |, |relsize3 |integer |1       |\eqn{[1, \infty)}{[1, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   relsize1 \tab integer \tab 2 \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   relsize2 \tab integer \tab 2 \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   relsize3 \tab integer \tab 1 \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_circle.Rd
+++ b/man/mlr_task_generators_circle.Rd
@@ -18,8 +18,10 @@ tgen("circle")
 }
 
 \section{Parameters}{
-
-, |Id |Type    |Default |Range                       |, |:--|:-------|:-------|:---------------------------|, |d  |integer |2       |\eqn{[2, \infty)}{[2, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   d \tab integer \tab 2 \tab \eqn{[2, \infty)}{[2, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_friedman1.Rd
+++ b/man/mlr_task_generators_friedman1.Rd
@@ -17,8 +17,10 @@ tgen("friedman1")
 }
 
 \section{Parameters}{
-
-, |Id |Type    |Default |Range                       |, |:--|:-------|:-------|:---------------------------|, |sd |numeric |1       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   sd \tab numeric \tab 1 \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_moons.Rd
+++ b/man/mlr_task_generators_moons.Rd
@@ -18,8 +18,10 @@ tgen("moons")
 }
 
 \section{Parameters}{
-
-, |Id    |Type    |Default |Range                       |, |:-----|:-------|:-------|:---------------------------|, |sigma |numeric |1       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   sigma \tab numeric \tab 1 \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_simplex.Rd
+++ b/man/mlr_task_generators_simplex.Rd
@@ -20,8 +20,13 @@ tgen("simplex")
 }
 
 \section{Parameters}{
-
-, |Id     |Type    |Default |Levels      |Range                       |, |:------|:-------|:-------|:-----------|:---------------------------|, |center |logical |TRUE    |TRUE, FALSE |-                           |, |d      |integer |3       |            |\eqn{[1, \infty)}{[1, Inf)} |, |sd     |numeric |0.1     |            |\eqn{[0, \infty)}{[0, Inf)} |, |sides  |integer |1       |            |\eqn{[1, \infty)}{[1, Inf)} |
+\tabular{lllll}{
+   Id \tab Type \tab Default \tab Levels \tab Range \cr
+   center \tab logical \tab TRUE \tab TRUE, FALSE \tab - \cr
+   d \tab integer \tab 3 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   sd \tab numeric \tab 0.1 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   sides \tab integer \tab 1 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_smiley.Rd
+++ b/man/mlr_task_generators_smiley.Rd
@@ -17,8 +17,11 @@ tgen("smiley")
 }
 
 \section{Parameters}{
-
-, |Id  |Type    |Default |Range                       |, |:---|:-------|:-------|:---------------------------|, |sd1 |numeric |-       |\eqn{[0, \infty)}{[0, Inf)} |, |sd2 |numeric |-       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   sd1 \tab numeric \tab - \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+   sd2 \tab numeric \tab - \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_spirals.Rd
+++ b/man/mlr_task_generators_spirals.Rd
@@ -17,8 +17,11 @@ tgen("spirals")
 }
 
 \section{Parameters}{
-
-, |Id     |Type    |Default |Range                       |, |:------|:-------|:-------|:---------------------------|, |cycles |integer |1       |\eqn{[1, \infty)}{[1, Inf)} |, |sd     |numeric |0       |\eqn{[0, \infty)}{[0, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   cycles \tab integer \tab 1 \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+   sd \tab numeric \tab 0 \tab \eqn{[0, \infty)}{[0, Inf)} \cr
+}
 }
 
 \examples{

--- a/man/mlr_task_generators_xor.Rd
+++ b/man/mlr_task_generators_xor.Rd
@@ -17,8 +17,10 @@ tgen("xor")
 }
 
 \section{Parameters}{
-
-, |Id |Type    |Default |Range                       |, |:--|:-------|:-------|:---------------------------|, |d  |integer |1       |\eqn{[1, \infty)}{[1, Inf)} |
+\tabular{llll}{
+   Id \tab Type \tab Default \tab Range \cr
+   d \tab integer \tab 1 \tab \eqn{[1, \infty)}{[1, Inf)} \cr
+}
 }
 
 \examples{

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -326,3 +326,29 @@ test_that("disable cloning", {
   expect_identical(learner$hash, bmr$learners$learner[[1]]$hash)
   expect_identical(resampling$hash, bmr$resamplings$resampling[[1]]$hash)
 })
+
+test_that("task and learner assertions", {
+  grid = benchmark_grid(
+    task = tsks(c("iris", "boston_housing")),
+    learners = lrn("classif.rpart"),
+    resamplings = rsmp("holdout")
+  )
+
+  expect_error(benchmark(grid), "task types")
+
+  grid = benchmark_grid(
+    task = tsk("iris"),
+    learners = lrns(c("classif.rpart", "regr.rpart")),
+    resamplings = rsmp("holdout")
+  )
+
+  expect_error(benchmark(grid), "learner types")
+
+  grid = benchmark_grid(
+    task = tsk("iris"),
+    learners = lrn("regr.rpart"),
+    resamplings = rsmp("holdout")
+  )
+
+  expect_error(benchmark(grid), "not match type")
+})

--- a/tests/testthat/test_mlr_reflections.R
+++ b/tests/testthat/test_mlr_reflections.R
@@ -1,4 +1,8 @@
-old_mlr_reflections = as.environment(as.list(mlr_reflections, all.names=TRUE))
+old_mlr_reflections = as.environment(as.list(mlr_reflections, all.names = TRUE))
+
+on.exit({
+  mlr_reflections = as.environment(as.list(old_mlr_reflections, all.names = TRUE))
+})
 
 mlr_reflections$task_types = setkeyv(rbind(mlr_reflections$task_types, rowwise_table(
   ~type,  ~package, ~task,              ~learner,        ~prediction,         ~prediction_data,        ~measure,
@@ -72,5 +76,3 @@ test_that("set column roles works", {
   expect_task(task$set_col_roles("age", "test"))
   expect_equal(task$col_roles$test, "age")
 })
-
-mlr_reflections = as.environment(as.list(old_mlr_reflections, all.names=TRUE))

--- a/tests/testthat/test_mlr_reflections.R
+++ b/tests/testthat/test_mlr_reflections.R
@@ -1,0 +1,76 @@
+old_mlr_reflections = as.environment(as.list(mlr_reflections, all.names=TRUE))
+
+mlr_reflections$task_types = setkeyv(rbind(mlr_reflections$task_types, rowwise_table(
+  ~type,  ~package, ~task,              ~learner,        ~prediction,         ~prediction_data,        ~measure,
+  "test", "mlr3",   "TaskClassifTest", "LearnerClassif", "PredictionClassif", "PredictionDataClassif", "MeasureClassif"
+)), "type")
+
+mlr_reflections$task_col_roles$test = c(mlr_reflections$task_col_roles$classif, "test")
+mlr_reflections$task_properties$test = mlr_reflections$task_properties$classif
+mlr_reflections$default_measures$test = "classif.ce"
+
+TaskClassifTest = R6Class("TaskClassifTest",
+  inherit = TaskClassif,
+  public = list(
+    initialize = function(id, backend, target, positive = NULL, label = NA_character_, extra_args = list()) {
+      super$initialize(id = id, backend = backend, target = target, label = label, extra_args = extra_args)
+
+      self$task_type = "test"
+      new_col_roles = named_list(setdiff(mlr_reflections$task_col_roles[["test"]], names(private$.col_roles)), character(0))
+      private$.col_roles = insert_named(private$.col_roles, new_col_roles)
+
+      update_classif_property(self, private)
+    }
+  )
+)
+
+b = as_data_backend(load_dataset("PimaIndiansDiabetes2", "mlbench"))
+task = TaskClassifTest$new("test", b, target = "diabetes", positive = "pos", label = "Pima Indian Diabetes")
+learner = lrn("classif.rpart")
+measure = msr("classif.ce")
+
+test_that("assertions work", {
+  expect_learner(assert_learner(learner, task))
+  expect_null(assert_task_learner(task, learner))
+  expect_measure(assert_measure(measure, task, learner))
+})
+
+test_that("train and predict works", {
+  expect_learner(learner$train(task))
+  expect_prediction(learner$predict(task))
+})
+
+test_that("resampling works", {
+  rr = resample(task, learner, rsmp("cv", folds = 3))
+  expect_equal(rr$task_type, "test")
+
+  scores = rr$score(msr("classif.ce"))
+  expect_list(scores$prediction, "Prediction")
+  expect_numeric(scores$classif.ce, any.missing = FALSE)
+  expect_number(rr$aggregate(msr("classif.ce")))
+
+  scores = rr$score()
+  expect_list(scores$prediction, "Prediction")
+  expect_numeric(scores$classif.ce, any.missing = FALSE)
+  expect_number(rr$aggregate(msr("classif.ce")))
+})
+
+test_that("benchmark works", {
+  grid = benchmark_grid(task, learner, rsmp("cv", folds = 3))
+  bmr = benchmark(grid)
+  expect_benchmark_result(bmr)
+  expect_equal(bmr$task_type, "test")
+  tab = bmr$aggregate(measure)
+  expect_data_table(tab, nrows = 1L)
+  expect_names(names(tab), type = "unique", identical.to = c("nr", "resample_result", "task_id", "learner_id", "resampling_id", "iters", "classif.ce"))
+
+  grid = benchmark_grid(list(task, tsk("mtcars"), tsk("boston_housing")), learner, rsmp("cv", folds = 3))
+  expect_error(benchmark(grid), "Multiple task types detected")
+})
+
+test_that("set column roles works", {
+  expect_task(task$set_col_roles("age", "test"))
+  expect_equal(task$col_roles$test, "age")
+})
+
+mlr_reflections = as.environment(as.list(old_mlr_reflections, all.names=TRUE))


### PR DESCRIPTION
## Features

* A learner type can now work with different task types e.g.  `LearnerClassif` with `TaskClassif` and `TaskClassifST`
* Assertions between task and learner or task and measure are performed on classes instead of `task_type` (`mlr_reflections$task_types`)
* prediction data class is part of `mlr_reflections$task_types` now

## Reverse Dependencies

* mlr3cluster - https://github.com/mlr-org/mlr3cluster/pull/23 
* mlr3proba - https://github.com/mlr-org/mlr3proba/pull/286
* mlr3spatial - main branch depends on this PR
* mlr3spatiotempcv - https://github.com/mlr-org/mlr3spatiotempcv/pull/207