### PR TITLE
feat: pass test set to train method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3 0.14.0-9000
 
-* Test set is available to the Learner for early stopping.
+* Test set is available to the `Learner` for early stopping.
 
 # mlr3 0.14.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mlr3 0.14.0-9000
+
+* Test set is available to the Learner for early stopping.
+
 # mlr3 0.14.0
 
 * Added multiclass measures: `mauc_aunu`, `mauc_aunp`, `mauc_au1u`, `mauc_au1p`.

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -237,7 +237,10 @@ Learner = R6Class("Learner",
         mode = "hotstart"
       }
 
-      learner_train(learner, task, row_ids, mode)
+      train_row_ids = if (!is.null(row_ids)) row_ids else task$row_roles$use
+      test_row_ids = task$row_roles$test
+
+      learner_train(learner, task, train_row_ids = row_ids, test_row_ids = test_row_ids, mode = mode)
 
       # store the task w/o the data
       self$state$train_task = task_rm_backend(task$clone(deep = TRUE))

--- a/R/Task.R
+++ b/R/Task.R
@@ -144,7 +144,7 @@ Task = R6Class("Task",
       )
 
       cn = self$col_info$id # note: this sorts the columns!
-      private$.row_roles = list(use = rn, holdout = integer(), early_stopping = integer())
+      private$.row_roles = list(use = rn, test = integer(), holdout = integer())
       private$.col_roles = named_list(mlr_reflections$task_col_roles[[task_type]], character())
       private$.col_roles$feature = setdiff(cn, self$backend$primary_key)
       self$extra_args = assert_list(extra_args, names = "unique")
@@ -693,7 +693,7 @@ Task = R6Class("Task",
     hash = function(rhs) {
       private$.hash %??% calculate_hash(
         class(self), self$id, self$backend$hash, self$col_info,
-        private$.row_roles, private$.col_roles, private$.properties
+        remove_named(private$.row_roles, "test"), private$.col_roles, private$.properties
       )
     },
 
@@ -766,15 +766,14 @@ Task = R6Class("Task",
     #' Each row (observation) can have an arbitrary number of roles in the learning task:
     #'
     #' - `"use"`: Use in train / predict / resampling.
+    #' - `"test"`: Observations are hold back unless explicitly queried.
+    #'   Can be queried by a [Learner] to determine a good iteration to stop by evaluating the performance
+    #'   on external data, e.g. the XGboost learner in \CRANpkg{mlr3learners} for parameter `nrounds`.
     #' - `"holdout"`: Observations are hold back unless explicitly queried.
     #'   Can be used, e.g., as truly independent holdout set:
     #'
     #'   1. Add `"holdout"` to the `predict_sets` of a [Learner].
     #'   2. Configure a [Measure] to use the `"holdout"` set by updating its `predict_sets` field.
-    #'
-    #' - `"early_stopping"`: Observations are hold back unless explicitly queried.
-    #'   Can be queried by a [Learner] to determine a good iteration to stop by evaluating the performance
-    #'   on external data, e.g. the XGboost learner in \CRANpkg{mlr3learners} for parameter `nrounds`.
     #'
     #' `row_roles` is a named list whose elements are named by row role and each element is an `integer()` vector of row ids.
     #' To alter the roles, just modify the list, e.g. with  \R's set functions ([intersect()], [setdiff()], [union()], \ldots).

--- a/R/helper_hashes.R
+++ b/R/helper_hashes.R
@@ -16,6 +16,8 @@ phashes = function(x) {
 #' @noRd
 task_hashes = function(task, resampling) {
   row_roles = get_private(task)$.row_roles
+  # test role is set on the worker
+  row_roles = remove_named(row_roles, "test")
   map_chr(seq_len(resampling$iters), function(i) {
     train_set = resampling$train_set(i)
     row_roles$use = train_set

--- a/R/mlr_reflections.R
+++ b/R/mlr_reflections.R
@@ -93,7 +93,7 @@ local({
   )
 
   mlr_reflections$task_row_roles = c(
-    "use", "holdout", "early_stopping"
+    "use", "test", "holdout"
   )
 
   tmp = c("feature", "target", "name", "order", "stratum", "group", "weight")

--- a/R/worker.R
+++ b/R/worker.R
@@ -1,4 +1,4 @@
-learner_train = function(learner, task, row_ids = NULL, mode = "train") {
+learner_train = function(learner, task, train_row_ids = NULL, test_row_ids = NULL, mode = "train") {
   # This wrapper calls learner$train, and additionally performs some basic
   # checks that the training was successful.
   # Exceptions here are possibly encapsulated, so that they get captured
@@ -29,17 +29,26 @@ learner_train = function(learner, task, row_ids = NULL, mode = "train") {
   require_namespaces(learner$packages)
 
   # subset to train set w/o cloning
-  if (!is.null(row_ids)) {
+  if (!is.null(train_row_ids)) {
     lg$debug("Subsetting task '%s' to %i rows",
-      task$id, length(row_ids), task = task$clone(), row_ids = row_ids)
+      task$id, length(train_row_ids), task = task$clone(), row_ids = train_row_ids)
 
     prev_use = task$row_roles$use
     on.exit({
       task$row_roles$use = prev_use
     }, add = TRUE)
-    task$row_roles$use = row_ids
+    task$row_roles$use = train_row_ids
   } else {
     lg$debug("Skip subsetting of task '%s'", task$id)
+  }
+
+  # pass test ids w/o cloning
+  if (!is.null(test_row_ids)) {
+    prev_test = task$row_roles$test
+    on.exit({
+      task$row_roles$test = prev_test
+    }, add = TRUE)
+    task$row_roles$test = test_row_ids
   }
 
   if (mode == "train") learner$state = list()
@@ -237,7 +246,7 @@ workhorse = function(iteration, task, learner, resampling, lgr_threshold, store_
   )
 
   # train model
-  learner = learner_train(learner$clone(), task, sets[["train"]], mode = mode)
+  learner = learner_train(learner$clone(), task, sets[["train"]], sets[["test"]], mode = mode)
 
   # predict for each set
   sets = sets[learner$predict_sets]

--- a/tests/testthat/test_mlr_learners_classif_debug.R
+++ b/tests/testthat/test_mlr_learners_classif_debug.R
@@ -44,20 +44,17 @@ test_that("NA predictions", {
   expect_equal(is.na(p$response), apply(p$prob, 1, anyMissing))
 })
 
-test_that("early_stopping set is available", {
+test_that("test set is available in $.train method", {
   task = tsk("iris")
-  task$set_row_roles(1:10, roles = "early_stopping")
   learner = lrn("classif.debug", save_tasks = TRUE)
-  learner$train(task)
+  resampling = rsmp("cv", folds = 3)
+  resampling$instantiate(task)
 
-  row_roles = learner$model$task_train$row_roles
-  expect_names(names(row_roles), permutation.of = c("use", "holdout", "early_stopping"))
-  expect_equal(row_roles$early_stopping, seq(10))
-
-  rr = resample(task, learner, rsmp("cv", folds = 3), store_models = TRUE)
+  rr = resample(task, learner, resampling, store_models = TRUE)
 
   walk(seq(rr$iters), function(i) {
-    expect_equal(rr$learners[[i]]$model$task_train$row_roles$early_stopping, seq(10))
+    expect_equal(rr$learners[[i]]$model$task_train$row_roles$use, resampling$train_set(i))
+    expect_equal(rr$learners[[i]]$model$task_train$row_roles$test, resampling$test_set(i))
   })
 })
 


### PR DESCRIPTION
* Rows with the `"test"` role are held back like rows with the `"holdout"` role.
* Rows are available to the learner in the `$.train` method
* Can be used e.g. by XGBoost for early stopping
* While resampling, the test set is automatically placed in the `"test"` role 
* While training, the test set must be set in the task by the user


```r
# training
task = tsk("iris")
task$set_row_roles(1:10, roles = "test")
learner = lrn("classif.debug", save_tasks = TRUE)

learner$train(task)

learner$model$task_train$row_roles
#> $use
#>   [1]  11  12  13  14  15  16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34  35  36  37  38
#>  [29]  39  40  41  42  43  44  45  46  47  48  49  50  51  52  53  54  55  56  57  58  59  60  61  62  63  64  65  66
#>  [57]  67  68  69  70  71  72  73  74  75  76  77  78  79  80  81  82  83  84  85  86  87  88  89  90  91  92  93  94
#>  [85]  95  96  97  98  99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122
#> [113] 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150
#> 
#> $test
#>  [1]  1  2  3  4  5  6  7  8  9 10
#> 
#> $holdout
#> integer(0)

# resampling
task = tsk("iris")
learner = lrn("classif.debug", save_tasks = TRUE)
resampling = rsmp("cv", folds = 3)
resampling$instantiate(task)

rr = resample(task, learner, resampling, store_models = TRUE)

rr$learners[[1]]$model$task_train$row_roles$test
#>  [1]   7   8   9  12  13  16  18  23  25  26  31  32  36  38  40  42  47  50  52  58
#> [21]  61  63  72  73  74  77  78  81  86  88  92  94  95  98  99 101 103 106 107 109
#> [41] 110 114 121 127 130 133 136 147 149 150

resampling$test_set(1)
#>  [1]   7   8   9  12  13  16  18  23  25  26  31  32  36  38  40  42  47  50  52  58
#> [21]  61  63  72  73  74  77  78  81  86  88  92  94  95  98  99 101 103 106 107 109
#> [41] 110 114 121 127 130 133 136 147 149 150
```

