### PR TITLE
fix: elapsed time returned 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Removed depdency on package `distr6`.
 * Fixed reassembling of `GraphLearner`.
 * Test set is available to the `Learner` for early stopping.
+* Fixed bug that elapsed time measures were 0: https://stackoverflow.com/questions/73797845/mlr3-benchmarking-with-elapsed-time-measure
 
 # mlr3 0.14.0
 

--- a/R/MeasureElapsedTime.R
+++ b/R/MeasureElapsedTime.R
@@ -38,6 +38,7 @@ MeasureElapsedTime = R6Class("MeasureElapsedTime",
         predict_type = NA_character_,
         range = c(0, Inf),
         minimize = TRUE,
+        properties = "requires_learner",
         label = "Elapsed Time",
         man = "mlr3::mlr_measures_elapsed_time"
       )

--- a/tests/testthat/test_Measure.R
+++ b/tests/testthat/test_Measure.R
@@ -123,3 +123,9 @@ test_that("time_train works with different predict type (#832)", {
   res = rr$score(msr("time_train"))
   expect_number(res$time_train)
 })
+
+test_that("time_train is > 0", {
+  rr = resample(tsk("iris"), lrn("classif.debug"), rsmp("holdout"))
+  res = rr$score(msr("time_train"))
+  expect_true(res$time_train > 0)
+})


### PR DESCRIPTION
See here: https://stackoverflow.com/questions/73797845/mlr3-benchmarking-with-elapsed-time-measure