### PR TITLE
correct ResamplingSubsampling documented id

### DIFF
--- a/R/ResamplingSubsampling.R
+++ b/R/ResamplingSubsampling.R
@@ -7,7 +7,7 @@
 #' Splits data `repeats` (default: 30) times into training and test set
 #' with a ratio of `ratio` (default: 2/3) observations going into the training set.
 #'
-#' @templateVar id holdout
+#' @templateVar id subsampling
 #' @template resampling
 #'
 #' @section Parameters:


### PR DESCRIPTION
https://mlr3.mlr-org.com/reference/mlr_resamplings_subsampling.html documentation is wrong: the `rsmp()` call lists this as `rsmp("holdout")`, but should be `rsmp("subsampling")`.

