### PR TITLE
feat: Resampling saves param vals during instantiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mlr3 0.15.0-9000
+
+* The Resampling object now also stores the parameter values that were set during instantiation.
+
 # mlr3 0.15.0
 
 * Many returned tables are now assigned a class for a `print` method to make the output

--- a/R/Resampling.R
+++ b/R/Resampling.R
@@ -159,6 +159,8 @@ Resampling = R6Class("Resampling",
     #' @description
     #' Materializes fixed training and test splits for a given task and stores them in `r$instance`
     #' in an arbitrary format.
+    #' The parameter values that were used during initialization are also stored and can be accessed using the
+    #' `$param_vals` field.
     #'
     #' @param task ([Task])\cr
     #'   Task used for instantiation.
@@ -167,6 +169,7 @@ Resampling = R6Class("Resampling",
     #' Returns the object itself, but modified **by reference**.
     #' You need to explicitly `$clone()` the object beforehand if you want to keeps
     #' the object in its previous state.
+    #'
     instantiate = function(task) {
       task = assert_task(as_task(task))
       strata = task$strata
@@ -187,6 +190,7 @@ Resampling = R6Class("Resampling",
       }
 
       self$instance = instance
+      private$.param_vals = self$param_set$values
       self$task_hash = task$hash
       self$task_nrow = task$nrow
       invisible(self)
@@ -228,11 +232,24 @@ Resampling = R6Class("Resampling",
         return(NA_character_)
       }
       calculate_hash(list(class(self), self$id, self$param_set$values, self$instance))
+    },
+    #' @field param_vals (`list()`)\cr
+    #' The parameter values that were set during instantiation.
+    param_vals = function(rhs) {
+      assert_ro_binding(rhs)
+
+      if (!self$is_instantiated) {
+        NULL
+      } else {
+        private$.param_vals
+      }
+
     }
   ),
 
   private = list(
     .groups = NULL,
+    .param_vals = NULL,
 
     .get_set = function(getter, i) {
       if (!self$is_instantiated) {

--- a/R/Resampling.R
+++ b/R/Resampling.R
@@ -233,17 +233,18 @@ Resampling = R6Class("Resampling",
       }
       calculate_hash(list(class(self), self$id, self$param_set$values, self$instance))
     },
-    #' @field param_vals (`list()`)\cr
+    #' @field param_vals (named `list()`)\cr
     #' The parameter values that were set during instantiation.
+    #' Returns `NULL` if the resampling has not been instantiated yet.
     param_vals = function(rhs) {
       assert_ro_binding(rhs)
 
       if (!self$is_instantiated) {
+        warningf("Resampling is not instantiated.")
         NULL
       } else {
         private$.param_vals
       }
-
     }
   ),
 

--- a/man/Resampling.Rd
+++ b/man/Resampling.Rd
@@ -149,6 +149,9 @@ Is \code{TRUE} if the resampling has been instantiated.}
 
 \item{\code{hash}}{(\code{character(1)})\cr
 Hash (unique identifier) for this object.}
+
+\item{\code{param_vals}}{(\code{list()})\cr
+The parameter values that were set during instantiation.}
 }
 \if{html}{\out{</div>}}
 }
@@ -254,6 +257,8 @@ Opens the corresponding help page referenced by field \verb{$man}.
 \subsection{Method \code{instantiate()}}{
 Materializes fixed training and test splits for a given task and stores them in \code{r$instance}
 in an arbitrary format.
+The parameter values that were used during initialization are also stored and can be accessed using the
+\verb{$param_vals} field.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Resampling$instantiate(task)}\if{html}{\out{</div>}}
 }

--- a/man/Resampling.Rd
+++ b/man/Resampling.Rd
@@ -150,8 +150,9 @@ Is \code{TRUE} if the resampling has been instantiated.}
 \item{\code{hash}}{(\code{character(1)})\cr
 Hash (unique identifier) for this object.}
 
-\item{\code{param_vals}}{(\code{list()})\cr
-The parameter values that were set during instantiation.}
+\item{\code{param_vals}}{(named \code{list()})\cr
+The parameter values that were set during instantiation.
+Returns \code{NULL} if the resampling has not been instantiated yet.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_Resampling.R
+++ b/tests/testthat/test_Resampling.R
@@ -160,3 +160,11 @@ test_that("loo with groups", {
   tab = merge(as.data.table(loo), islands, by = "row_id")
   expect_true(all(tab[, .(n_islands = uniqueN(island)), by = row_id]$n_islands == 1L))
 })
+
+test_that("Parameter values are stored in the instance", {
+  res = rsmp("cv")
+  task = tsk("mtcars")
+  res$param_set$values$folds = 3
+  res$instantiate(task)
+  expect_true(res$param_vals == 3)
+})


### PR DESCRIPTION
Some inference method that e.g. provide confidence intervals for the generalization error need access to these parameter values. Currently we had to trust the parameter values are not changed after instantiation, which is suboptimal.