### PR TITLE
feat: add argument `paired` to `benchmark_grid()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# mlr3 0.15.0-9000
+
+* Added argument `paired` to `benchmark_grid()` function, which can be used to create a benchmark design, where
+  resamplings have been instantiated on tasks.
+
 # mlr3 0.15.0
 
 * Many returned tables are now assigned a class for a `print` method to make the output

--- a/R/benchmark_grid.R
+++ b/R/benchmark_grid.R
@@ -4,13 +4,21 @@
 #' Takes a lists of [Task], a list of [Learner] and a list of [Resampling] to
 #' generate a design in an [expand.grid()] fashion (a.k.a. cross join or Cartesian product).
 #'
-#' Resampling strategies are not allowed to be instantiated when passing the argument, and instead will be instantiated per task internally.
-#' The only exception to this rule applies if all tasks have exactly the same number of rows, and the resamplings are all instantiated for such tasks.
+#' There are two modes of operation, depending on the flag `paired`.
+#'
+#' * With `paired` set to `FALSE` (default), resampling strategies are not allowed to be instantiated, and instead will be instantiated per task internally.
+#'   The only exception to this rule applies if all tasks have exactly the same number of rows, and the resamplings are all instantiated for such tasks.
+#'   The grid will be generated based on the Cartesian product of tasks, learners, and resamplings.
+#' * With `paired` set to `TRUE`, tasks and resamplings are treated as pairs.
+#'   I.e., you must provide as many tasks as corresponding instantiated resamplings.
+#'   The grid will be generated based on the Cartesian product of learners and pairs.
 #'
 #' @param tasks (list of [Task]).
 #' @param learners (list of [Learner]).
 #' @param resamplings (list of [Resampling]).
-#' @param paired (logical) Set this to `TRUE` if the resamplings are instantiated on the tasks, i.e. the tasks and resamplings are paired.
+#' @param paired (`logical(1)`)\cr
+#'   Set this to `TRUE` if the resamplings are instantiated on the tasks, i.e., the tasks and resamplings are paired.
+#'   You need to provide the same number of tasks and instantiated resamplings.
 #'
 #' @return ([data.table::data.table()]) with the cross product of the input vectors.
 #'
@@ -55,13 +63,20 @@ benchmark_grid = function(tasks, learners, resamplings, paired = FALSE) {
   learners = assert_learners(as_learners(learners))
   resamplings = assert_resamplings(as_resamplings(resamplings))
 
-  if (paired) {
-    assert_true(length(tasks) == length(resamplings))
-    assert_true(all(map_lgl(resamplings, "is_instantiated")))
-    task_hashes = map_chr(tasks, "hash")
-    resampling_hashes = map_chr(resamplings, "task_hash")
-    if (!all(task_hashes == resampling_hashes)) {
-      stopf("If paired is `TRUE`, the resamplings must be instantiated on their task.")
+  if (assert_flag(paired)) {
+    if (length(tasks) != length(resamplings)) {
+      stopf("If `paired` is `TRUE`, you need to provide the same number of tasks and instantiated resamplings")
+    }
+
+    for (i in seq_along(tasks)) {
+      task = tasks[[i]]
+      resampling = resamplings[[i]]
+      if (!resamplings[[i]]$is_instantiated) {
+        stopf("Resampling #%i ('%s' for task '%s') is not instantiated", i, resampling$id, task$id)
+      }
+      if (resampling$task_hash != task$hash) {
+        stopf("Resampling #%i ('%s' for task '%s') is not instantiated on the corresponding task", i, resampling$id, task$id)
+      }
     }
 
     grid = CJ(task = seq_along(tasks), learner = seq_along(learners))
@@ -72,33 +87,31 @@ benchmark_grid = function(tasks, learners, resamplings, paired = FALSE) {
       learner = learners[grid$learner],
       resampling = resamplings[grid$task]
     )
-
-    set_data_table_class(tab, "benchmark_grid")
-    return(tab)
-  }
-
-  grid = CJ(task = seq_along(tasks), resampling = seq_along(resamplings))
-  is_instantiated = map_lgl(resamplings, "is_instantiated")
-
-  if (any(is_instantiated)) {
-    task_nrow = unique(map_int(tasks, "nrow"))
-    if (length(task_nrow) != 1L) {
-      stopf("All resamplings must be uninstantiated, or must operate on tasks with the same number of rows")
-    }
-    if (!identical(task_nrow, unique(map_int(resamplings, "task_nrow")))) {
-      stop("A Resampling is instantiated for a task with a different number of observations")
-    }
-    instances = pmap(grid, function(task, resampling) resamplings[[resampling]]$clone())
   } else {
-    instances = pmap(grid, function(task, resampling) resamplings[[resampling]]$clone()$instantiate(tasks[[task]]))
+    grid = CJ(task = seq_along(tasks), resampling = seq_along(resamplings))
+    is_instantiated = map_lgl(resamplings, "is_instantiated")
+
+    if (any(is_instantiated)) {
+      task_nrow = unique(map_int(tasks, "nrow"))
+      if (length(task_nrow) != 1L) {
+        stopf("All resamplings must be uninstantiated, or must operate on tasks with the same number of rows")
+      }
+      if (!identical(task_nrow, unique(map_int(resamplings, "task_nrow")))) {
+        stop("A Resampling is instantiated for a task with a different number of observations")
+      }
+      instances = pmap(grid, function(task, resampling) resamplings[[resampling]]$clone())
+    } else {
+      instances = pmap(grid, function(task, resampling) resamplings[[resampling]]$clone()$instantiate(tasks[[task]]))
+    }
+
+    grid$instance = seq_row(grid)
+    grid = grid[CJ(task = seq_along(tasks), learner = seq_along(learners)), on = "task", allow.cartesian = TRUE]
+
+    tab = data.table(task = tasks[grid$task], learner = learners[grid$learner], resampling = instances[grid$instance])
   }
 
-  grid$instance = seq_row(grid)
-  grid = grid[CJ(task = seq_along(tasks), learner = seq_along(learners)), on = "task", allow.cartesian = TRUE]
-
-  tab = data.table(task = tasks[grid$task], learner = learners[grid$learner], resampling = instances[grid$instance])
   set_data_table_class(tab, "benchmark_grid")
-  tab
+  return(tab)
 }
 
 #' @export

--- a/R/benchmark_grid.R
+++ b/R/benchmark_grid.R
@@ -27,6 +27,17 @@
 #' benchmark(grid)
 #' }
 #'
+#' # paired
+#' learner = lrn("classif.rpart")
+#' task1 = tsk("penguins")
+#' task2 = tsk("german_credit")
+#' res1 = rsmp("holdout")
+#' res2 = rsmp("holdout")
+#' res1$instantiate(task1)
+#' res2$instantiate(task2)
+#' design = benchmark_grid(list(task1, task2), learner, list(res1, res2), paired = TRUE)
+#' print(design)
+#'
 #' # manual construction of the grid with data.table::CJ()
 #' grid = data.table::CJ(task = tasks, learner = learners,
 #'   resampling = resamplings, sorted = FALSE)
@@ -39,24 +50,6 @@
 #' benchmark(grid)
 #' }
 #'
-#' # paired
-
-if (FALSE) {
-  learner = lrn("classif.rpart")
-  task1 = tsk("penguins")
-  task2 = tsk("german_credit")
-
-  res1 = rsmp("holdout")
-  res2 = rsmp("holdout")
-
-  res1$instantiate(task1)
-  res2$instantiate(task2)
-
-  design = benchmark_grid(list(task1, task2), learner, list(res1, res2), paired = TRUE)
-
-  print(design)
-}
-
 benchmark_grid = function(tasks, learners, resamplings, paired = FALSE) {
   tasks = assert_tasks(as_tasks(tasks))
   learners = assert_learners(as_learners(learners))

--- a/man/benchmark_grid.Rd
+++ b/man/benchmark_grid.Rd
@@ -13,7 +13,9 @@ benchmark_grid(tasks, learners, resamplings, paired = FALSE)
 
 \item{resamplings}{(list of \link{Resampling}).}
 
-\item{paired}{(logical) Set this to \code{TRUE} if the resamplings are instantiated on the tasks, i.e. the tasks and resamplings are paired.}
+\item{paired}{(\code{logical(1)})\cr
+Set this to \code{TRUE} if the resamplings are instantiated on the tasks, i.e., the tasks and resamplings are paired.
+You need to provide the same number of tasks and instantiated resamplings.}
 }
 \value{
 (\code{\link[data.table:data.table]{data.table::data.table()}}) with the cross product of the input vectors.
@@ -22,8 +24,15 @@ benchmark_grid(tasks, learners, resamplings, paired = FALSE)
 Takes a lists of \link{Task}, a list of \link{Learner} and a list of \link{Resampling} to
 generate a design in an \code{\link[=expand.grid]{expand.grid()}} fashion (a.k.a. cross join or Cartesian product).
 
-Resampling strategies are not allowed to be instantiated when passing the argument, and instead will be instantiated per task internally.
+There are two modes of operation, depending on the flag \code{paired}.
+\itemize{
+\item With \code{paired} set to \code{FALSE} (default), resampling strategies are not allowed to be instantiated, and instead will be instantiated per task internally.
 The only exception to this rule applies if all tasks have exactly the same number of rows, and the resamplings are all instantiated for such tasks.
+The grid will be generated based on the Cartesian product of tasks, learners, and resamplings.
+\item With \code{paired} set to \code{TRUE}, tasks and resamplings are treated as pairs.
+I.e., you must provide as many tasks as corresponding instantiated resamplings.
+The grid will be generated based on the Cartesian product of learners and pairs.
+}
 }
 \examples{
 tasks = list(tsk("penguins"), tsk("sonar"))

--- a/man/benchmark_grid.Rd
+++ b/man/benchmark_grid.Rd
@@ -4,7 +4,7 @@
 \alias{benchmark_grid}
 \title{Generate a Benchmark Grid Design}
 \usage{
-benchmark_grid(tasks, learners, resamplings)
+benchmark_grid(tasks, learners, resamplings, paired = FALSE)
 }
 \arguments{
 \item{tasks}{(list of \link{Task}).}
@@ -12,6 +12,8 @@ benchmark_grid(tasks, learners, resamplings)
 \item{learners}{(list of \link{Learner}).}
 
 \item{resamplings}{(list of \link{Resampling}).}
+
+\item{paired}{(logical) Set this to \code{TRUE} if the resamplings are instantiated on the tasks, i.e. the tasks and resamplings are paired.}
 }
 \value{
 (\code{\link[data.table:data.table]{data.table::data.table()}}) with the cross product of the input vectors.
@@ -34,6 +36,17 @@ print(grid)
 benchmark(grid)
 }
 
+# paired
+learner = lrn("classif.rpart")
+task1 = tsk("penguins")
+task2 = tsk("german_credit")
+res1 = rsmp("holdout")
+res2 = rsmp("holdout")
+res1$instantiate(task1)
+res2$instantiate(task2)
+design = benchmark_grid(list(task1, task2), learner, list(res1, res2), paired = TRUE)
+print(design)
+
 # manual construction of the grid with data.table::CJ()
 grid = data.table::CJ(task = tasks, learner = learners,
   resampling = resamplings, sorted = FALSE)
@@ -45,6 +58,7 @@ Map(function(task, resampling) {
 \dontrun{
 benchmark(grid)
 }
+
 }
 \seealso{
 \itemize{

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -356,10 +356,10 @@ test_that("task and learner assertions", {
 
 test_that("benchmark_grid works if paired = TRUE", {
   tasks = mlr3::tsks(c("pima", "iris"))
-  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
-  resampling = mlr3::rsmp("cv")
+  learners = lrns(c("classif.featureless", "classif.rpart"))
+  resampling = rsmp("cv")
   resamplings = pmap(
-    list(tasks, mlr3::rsmps(c("cv", "holdout"))),
+    list(tasks, rsmps(c("cv", "holdout"))),
     function(task, resampling) resampling$instantiate(task)
   )
   design = benchmark_grid(tasks, learners, resamplings, paired = TRUE)
@@ -382,13 +382,13 @@ test_that("benchmark_grid works if paired = TRUE", {
 
   # Resamplings must be instantiated
   tasks = tsks(c("pima", "iris"))
-  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  learners = lrns(c("classif.featureless", "classif.rpart"))
   resamplings = mlr3::rsmps(c("cv", "holdout"))
   expect_error(benchmark_grid(tasks, learners, resamplings, paired = TRUE))
 
   # Resamplings and tasks must have the same length
   tasks = tsks(c("pima", "iris"))
-  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  learners = lrns(c("classif.featureless", "classif.rpart"))
   resamplings = pmap(
     list(tasks, mlr3::rsmps(c("cv", "holdout"))),
     function(task, resampling) resampling$instantiate(task)
@@ -399,8 +399,8 @@ test_that("benchmark_grid works if paired = TRUE", {
 
   # Resamplings and tasks must have corresponding hashes
 
-  tasks = mlr3::tsks(c("pima", "iris"))
-  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  tasks = tsks(c("pima", "iris"))
+  learners = lrns(c("classif.featureless", "classif.rpart"))
   resamplings = pmap(
     list(tasks, mlr3::rsmps(c("cv", "holdout"))),
     function(task, resampling) resampling$instantiate(task)

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -352,3 +352,59 @@ test_that("task and learner assertions", {
 
   expect_error(benchmark(grid), "not match type")
 })
+
+
+test_that("benchmark_grid works if paired = TRUE", {
+  tasks = mlr3::tsks(c("pima", "iris"))
+  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  resampling = mlr3::rsmp("cv")
+  resamplings = pmap(
+    list(tasks, mlr3::rsmps(c("cv", "holdout"))),
+    function(task, resampling) resampling$instantiate(task)
+  )
+  design = benchmark_grid(tasks, learners, resamplings, paired = TRUE)
+  expect_class(design, "benchmark_grid")
+  # design[, identical(task), by = task]]
+  # expect(identical(design$resampling[class(learner)[[1]] ==)]))
+  expect_true(nrow(design) == 4L) #
+  expect_true(identical(design$task[[1]], design$task[[2]]))
+  expect_true(identical(design$task[[3]], design$task[[4]]))
+  expect_false(identical(design$task[[1]], design$task[[3]]))
+
+  expect_true(identical(design$resampling[[1]], design$resampling[[2]]))
+  expect_true(identical(design$resampling[[3]], design$resampling[[4]]))
+  expect_false(identical(design$resampling[[1]], design$resampling[[3]]))
+
+  expect_true(identical(design$learner[[1]], design$learner[[3]]))
+  expect_true(identical(design$learner[[2]], design$learner[[4]]))
+  expect_false(identical(design$learner[[2]], design$learner[[3]]))
+
+
+  # Resamplings must be instantiated
+  tasks = tsks(c("pima", "iris"))
+  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  resamplings = mlr3::rsmps(c("cv", "holdout"))
+  expect_error(benchmark_grid(tasks, learners, resamplings, paired = TRUE))
+
+  # Resamplings and tasks must have the same length
+  tasks = tsks(c("pima", "iris"))
+  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  resamplings = pmap(
+    list(tasks, mlr3::rsmps(c("cv", "holdout"))),
+    function(task, resampling) resampling$instantiate(task)
+  )
+  resamplings = c(resamplings, resamplings)
+  expect_error(benchmark_grid(tasks, learners, resamplings, paired = TRUE))
+
+
+  # Resamplings and tasks must have corresponding hashes
+
+  tasks = mlr3::tsks(c("pima", "iris"))
+  learners = suppressWarnings(mlr3::lrns(c("classif.featureless", "classif.rpart")))
+  resamplings = pmap(
+    list(tasks, mlr3::rsmps(c("cv", "holdout"))),
+    function(task, resampling) resampling$instantiate(task)
+  )
+  resamplings = rev(resamplings)
+  expect_error(benchmark_grid(tasks, learners, resamplings, paired = TRUE))
+})


### PR DESCRIPTION
This was already available in mlr3oml under the name `benchmark_grid_oml()`, but is generally useful.