### PR TITLE
feat(Learner): support additional checks on task

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * export generic function `col_info` to allow adding new methods for backends
 * Add `"mlr3.exec_chunk_bins"` option to split the resampling iterations into a number of bins.
-* Feat: `Learner` class now private methods `.verify_train_task(task, row_ids)` and
+* Feat: `Learner` class now supports private methods `.verify_train_task(task, row_ids)` and
 `verify_predict_task(task, row_ids)` that can be used to perform additional
 compatibility checks between the task and learner that should e.g. not trigger
 the use of the fallback learner

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * export generic function `col_info` to allow adding new methods for backends
 * Add `"mlr3.exec_chunk_bins"` option to split the resampling iterations into a number of bins.
+* Feat: `Learner` class now private methods `.verify_train_task(task, row_ids)` and
+`verify_predict_task(task, row_ids)` that can be used to perform additional
+compatibility checks between the task and learner that should e.g. not trigger
+the use of the fallback learner
 
 
 # mlr3 0.16.1

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -223,6 +223,9 @@ Learner = R6Class("Learner",
     train = function(task, row_ids = NULL) {
       task = assert_task(as_task(task))
       assert_learnable(task, self)
+      if (!is.null(private$.verify_train_task)) {
+        private$.verify_train_task(task, row_ids)
+      }
       row_ids = assert_row_ids(row_ids, null.ok = TRUE)
 
       if (!is.null(self$hotstart_stack)) {
@@ -268,6 +271,9 @@ Learner = R6Class("Learner",
       }
       task = assert_task(as_task(task))
       assert_predictable(task, self)
+      if (!is.null(private$.verify_predict_task)) {
+        private$.verify_predict_task(task, row_ids)
+      }
       row_ids = assert_row_ids(row_ids, null.ok = TRUE)
 
       if (is.null(self$state$model) && is.null(self$state$fallback_state$model)) {
@@ -518,7 +524,8 @@ Learner = R6Class("Learner",
     .predict_type = NULL,
     .param_set = NULL,
     .hotstart_stack = NULL,
-
+    .verify_train_task = NULL,
+    .verify_predict_task = NULL,
     deep_clone = function(name, value) {
       switch(name,
         .param_set = value$clone(deep = TRUE),


### PR DESCRIPTION
Some Learners (e.g.) in torch, need to do some additional input checks to verify whether a learner can train / predict on a task. 