### PR TITLE
feat(Learner): Allow for additional input checks on task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,7 +74,7 @@ Config/testthat/edition: 3
 Config/testthat/parallel: false
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.3.9000
 Collate:
     'mlr_reflections.R'
     'BenchmarkResult.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3 (development version)
 
-* feat(Learner): Add support for a `$check_task()` method that can be
+* feat(Learner): Add support for a `$check_learnable()` method that can be
                   implemented by `Learner`s to perform additional compatibility checks
 
 # mlr3 0.17.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mlr3 (development version)
 
+* feat(Learner): Add support for a `$check_task()` method that can be
+                  implemented by `Learner`s to perform additional compatibility checks
+
 # mlr3 0.17.2
 
 * Skip new `data.table` tests on mac.

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -85,7 +85,7 @@
 #' @section Additional Task Checks:
 #' Learner may perform custom compatibility checks on a task that determine whether a learner is applicable to a task
 #' using the optional `$check_task(task)` public method.
-#' When providing this method, it should either return `TRUE` or return the an error message as a `character(1)`.
+#' When providing this method, it should either return `TRUE` or return an error message as a `character(1)`.
 #'
 #' @template seealso_learner
 #' @export

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -21,7 +21,7 @@
 #' The dictionary [mlr_learners] gets automatically populated with the new learners as soon as the respective packages are loaded.
 #'
 #' More (experimental) learners can be found in the GitHub repository: \url{https://github.com/mlr-org/mlr3extralearners}.
-#' A guide on how to extend \CRANpkg{mlr3} with custom learners can be found in the [mlr3book](https://mlr3book.mlr-org.com).
+#' A guide on how to extend \CRANpkg{mlr3} with custom learners can be found in [mlr3extralearners](https://mlr3extralearners.mlr-org.com/articles/extending.html).
 #'
 #' To combine the learner with preprocessing operations like factor encoding, \CRANpkg{mlr3pipelines} is recommended.
 #' Hyperparameters stored in the `param_set` can be tuned with \CRANpkg{mlr3tuning}.
@@ -36,7 +36,6 @@
 #' @template param_packages
 #' @template param_label
 #' @template param_man
-#'
 #'
 #' @section Optional Extractors:
 #'
@@ -82,6 +81,11 @@
 #' ```
 #' lrn$param_set$add(paradox::ParamFct$new("foo", levels = c("a", "b")))
 #' ```
+#'
+#' @section Additional Task Checks:
+#' Learner may perform custom compatibility checks on a task that determine whether a learner is applicable to a task
+#' using the optional `$check_task(task)` public method.
+#' When providing this method, it should either return `TRUE` or return the an error message as a `character(1)`.
 #'
 #' @template seealso_learner
 #' @export

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -84,7 +84,7 @@
 #'
 #' @section Additional Task Checks:
 #' Learner may perform custom compatibility checks on a task that determine whether a learner is applicable to a task
-#' using the optional `$check_task(task)` public method.
+#' using the optional `$check_learnable(task)` public method.
 #' When providing this method, it should either return `TRUE` or return an error message as a `character(1)`.
 #'
 #' @template seealso_learner

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -153,6 +153,12 @@ assert_learnable = function(task, learner) {
   if (task$task_type == "unsupervised") {
     stopf("%s cannot be trained with %s", learner$format(), task$format())
   }
+  if (exists("check_task", envir = learner, inherits = FALSE)) {
+    msg = learner$check_task(task)
+    if (!isTRUE(msg)) {
+      stopf("Learner '%s' incompatible with task '%s': %s", learner$id, task$id, msg)
+    }
+  }
   assert_task_learner(task, learner)
 }
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -153,8 +153,8 @@ assert_learnable = function(task, learner) {
   if (task$task_type == "unsupervised") {
     stopf("%s cannot be trained with %s", learner$format(), task$format())
   }
-  if (exists("check_task", envir = learner, inherits = FALSE)) {
-    msg = learner$check_task(task)
+  if (exists("check_learnable", envir = learner, inherits = FALSE)) {
+    msg = learner$check_learnable(task)
     if (!isTRUE(msg)) {
       stopf("Learner '%s' incompatible with task '%s': %s", learner$id, task$id, msg)
     }

--- a/man/Learner.Rd
+++ b/man/Learner.Rd
@@ -23,7 +23,7 @@ Unsupervised cluster algorithms are implemented in \CRANpkg{mlr3cluster}.
 The dictionary \link{mlr_learners} gets automatically populated with the new learners as soon as the respective packages are loaded.
 
 More (experimental) learners can be found in the GitHub repository: \url{https://github.com/mlr-org/mlr3extralearners}.
-A guide on how to extend \CRANpkg{mlr3} with custom learners can be found in the \href{https://mlr3book.mlr-org.com}{mlr3book}.
+A guide on how to extend \CRANpkg{mlr3} with custom learners can be found in \href{https://mlr3extralearners.mlr-org.com/articles/extending.html}{mlr3extralearners}.
 
 To combine the learner with preprocessing operations like factor encoding, \CRANpkg{mlr3pipelines} is recommended.
 Hyperparameters stored in the \code{param_set} can be tuned with \CRANpkg{mlr3tuning}.
@@ -74,6 +74,13 @@ Here, we add a factor hyperparameter with id \code{"foo"} and possible levels \c
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{lrn$param_set$add(paradox::ParamFct$new("foo", levels = c("a", "b")))
 }\if{html}{\out{</div>}}
+}
+
+\section{Additional Task Checks}{
+
+Learner may perform custom compatibility checks on a task that determine whether a learner is applicable to a task
+using the optional \verb{$check_task(task)} public method.
+When providing this method, it should either return \code{TRUE} or return the an error message as a \code{character(1)}.
 }
 
 \seealso{

--- a/man/Learner.Rd
+++ b/man/Learner.Rd
@@ -79,8 +79,8 @@ Here, we add a factor hyperparameter with id \code{"foo"} and possible levels \c
 \section{Additional Task Checks}{
 
 Learner may perform custom compatibility checks on a task that determine whether a learner is applicable to a task
-using the optional \verb{$check_task(task)} public method.
-When providing this method, it should either return \code{TRUE} or return the an error message as a \code{character(1)}.
+using the optional \verb{$check_learnable(task)} public method.
+When providing this method, it should either return \code{TRUE} or return an error message as a \code{character(1)}.
 }
 
 \seealso{

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -325,11 +325,11 @@ test_that("Models can be replaced", {
   expect_equal(learner$model$location, 1)
 })
 
-test_that("check_task", {
+test_that("check_learnable", {
   learner = R6Class("LearnerClassifIris",
     inherit = LearnerClassifRpart,
     public = list(
-      check_task = function(task) {
+      check_learnable = function(task) {
         if (task$id == "iris") {
           return(TRUE)
         }

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -324,3 +324,19 @@ test_that("Models can be replaced", {
   learner$model$location = 1
   expect_equal(learner$model$location, 1)
 })
+
+test_that("check_task is used in assert_learnable", {
+  learner = R6Class("LearnerClassifIris",
+    inherit = LearnerClassifRpart,
+    public = list(
+      check_task = function(task) {
+        if (task$id == "iris") {
+          return(TRUE)
+        }
+        "This learner can only be trained on iris."
+      }
+    )
+  )$new()
+  expect_error(assert_learnable(tsk("iris"), learner), regexp = NA)
+  expect_error(assert_learnable(tsk("sonar"), learner), regexp = "iris")
+})

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -325,7 +325,7 @@ test_that("Models can be replaced", {
   expect_equal(learner$model$location, 1)
 })
 
-test_that("check_task is used in assert_learnable", {
+test_that("check_task", {
   learner = R6Class("LearnerClassifIris",
     inherit = LearnerClassifRpart,
     public = list(
@@ -337,6 +337,20 @@ test_that("check_task is used in assert_learnable", {
       }
     )
   )$new()
+  # assert_learnable
   expect_error(assert_learnable(tsk("iris"), learner), regexp = NA)
   expect_error(assert_learnable(tsk("sonar"), learner), regexp = "iris")
+
+  # benchmark() fails despite fallback
+  learner$fallback = lrn("classif.featureless")
+  expect_error(benchmark(benchmark_grid(tsk("iris"), learner, rsmp("holdout"))), regexp = NA)
+  expect_error(benchmark(benchmark_grid(tsk("sonar"), learner, rsmp("holdout"))), regexp = "iris")
+
+  # resample() fails despite fallback
+  expect_error(resample(tsk("iris"), learner, rsmp("holdout")), regexp = NA)
+  expect_error(resample(tsk("sonar"), learner, rsmp("holdout")), regexp = "iris")
+
+  # $train() does not trigger fallback
+  expect_error(learner$train(tsk("sonar")))
 })
+


### PR DESCRIPTION
By adding this feature, it is possible for learner's to perform custom compatibility checks. This is e.g. needed in torch, where we have a "tensor column", where the tensor can have different shapes. To verify that the tensor shapes fits together with the neural network, we want to perform input checks **before** calling into train, as incompatability is a user error and should not trigger the fallback learner

* [ ] In case this is accepted, add it do the "Extending" tutorial from mlr3extralearners.