### PR TITLE
perf: skip unnecessary clone of learner's state in `resample()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,7 +74,7 @@ Config/testthat/edition: 3
 Config/testthat/parallel: false
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Collate:
     'mlr_reflections.R'
     'BenchmarkResult.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * feat: dictionary conversion of `mlr_learners` respects prototype arguments
 recently added in mlr3misc
+* perf: skip unnecessary clone of learner's state in `resample()`
 
 # mlr3 0.17.2
 

--- a/R/as_learner.R
+++ b/R/as_learner.R
@@ -12,9 +12,20 @@ as_learner = function(x, ...) { # nolint
 }
 
 #' @export
+#' @param discard_state (`logical(1)`)
+#'   Whether to discard the state.
 #' @rdname as_learner
-as_learner.Learner = function(x, clone = FALSE, ...) { # nolint
-  if (isTRUE(clone)) x$clone(deep = TRUE) else x
+as_learner.Learner = function(x, clone = FALSE, discard_state = FALSE, ...) { # nolint
+  if (isTRUE(clone) && isTRUE(discard_state)) {
+    clone_without(x, "state")
+  } else if (isTRUE(clone)) {
+    x$clone(deep = TRUE)
+  } else if (isTRUE(discard_state)) {
+    x$state = NULL
+    x
+  } else {
+    x
+  }
 }
 
 #' @export

--- a/R/helper.R
+++ b/R/helper.R
@@ -39,3 +39,11 @@ print_data_table = function(x, hidden_columns) {
   }
   set_data_table_class(x, extra_class)
 }
+
+clone_without = function(x, y) {
+  y_prev = x[[y]]
+  x[[y]] = NULL
+  x2 = x$clone(deep = TRUE)
+  x[[y]] = y_prev
+  return(x2)
+}

--- a/R/resample.R
+++ b/R/resample.R
@@ -57,7 +57,7 @@
 resample = function(task, learner, resampling, store_models = FALSE, store_backends = TRUE, encapsulate = NA_character_, allow_hotstart = FALSE, clone = c("task", "learner", "resampling")) {
   assert_subset(clone, c("task", "learner", "resampling"))
   task = assert_task(as_task(task, clone = "task" %in% clone))
-  learner = assert_learner(as_learner(learner, clone = "learner" %in% clone, discard_state = "learner" %in% clone))
+  learner = assert_learner(as_learner(learner, clone = "learner" %in% clone, discard_state = TRUE))
   resampling = assert_resampling(as_resampling(resampling, clone = "resampling" %in% clone))
   assert_flag(store_models)
   assert_flag(store_backends)

--- a/R/resample.R
+++ b/R/resample.R
@@ -57,7 +57,7 @@
 resample = function(task, learner, resampling, store_models = FALSE, store_backends = TRUE, encapsulate = NA_character_, allow_hotstart = FALSE, clone = c("task", "learner", "resampling")) {
   assert_subset(clone, c("task", "learner", "resampling"))
   task = assert_task(as_task(task, clone = "task" %in% clone))
-  learner = assert_learner(as_learner(learner, clone = "learner" %in% clone))
+  learner = assert_learner(as_learner(learner, clone = "learner" %in% clone, discard_state = "learner" %in% clone))
   resampling = assert_resampling(as_resampling(resampling, clone = "resampling" %in% clone))
   assert_flag(store_models)
   assert_flag(store_backends)

--- a/man/BenchmarkResult.Rd
+++ b/man/BenchmarkResult.Rd
@@ -77,8 +77,8 @@ print(bmr)
 }
 
 Other benchmark: 
-\code{\link{benchmark_grid}()},
-\code{\link{benchmark}()}
+\code{\link{benchmark}()},
+\code{\link{benchmark_grid}()}
 }
 \concept{benchmark}
 \section{Active bindings}{

--- a/man/DataBackendDataTable.Rd
+++ b/man/DataBackendDataTable.Rd
@@ -32,8 +32,8 @@ e.g. SQL servers or \CRANpkg{duckdb}.
 }
 
 Other DataBackend: 
-\code{\link{DataBackendMatrix}},
 \code{\link{DataBackend}},
+\code{\link{DataBackendMatrix}},
 \code{\link{as_data_backend.Matrix}()}
 }
 \concept{DataBackend}

--- a/man/DataBackendMatrix.Rd
+++ b/man/DataBackendMatrix.Rd
@@ -34,8 +34,8 @@ e.g. SQL servers or \CRANpkg{duckdb}.
 }
 
 Other DataBackend: 
-\code{\link{DataBackendDataTable}},
 \code{\link{DataBackend}},
+\code{\link{DataBackendDataTable}},
 \code{\link{as_data_backend.Matrix}()}
 }
 \concept{DataBackend}

--- a/man/Learner.Rd
+++ b/man/Learner.Rd
@@ -98,13 +98,13 @@ for established default tuning spaces.
 Other Learner: 
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Public fields}{

--- a/man/LearnerClassif.Rd
+++ b/man/LearnerClassif.Rd
@@ -60,15 +60,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
-\code{\link{LearnerRegr}},
 \code{\link{Learner}},
+\code{\link{LearnerRegr}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super class}{

--- a/man/LearnerRegr.Rd
+++ b/man/LearnerRegr.Rd
@@ -50,15 +50,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
-\code{\link{LearnerClassif}},
 \code{\link{Learner}},
+\code{\link{LearnerClassif}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super class}{

--- a/man/Measure.Rd
+++ b/man/Measure.Rd
@@ -39,14 +39,14 @@ Other Measure:
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Public fields}{

--- a/man/MeasureClassif.Rd
+++ b/man/MeasureClassif.Rd
@@ -28,17 +28,17 @@ The default measure for classification is \code{\link[=mlr_measures_classif.ce]{
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/MeasureRegr.Rd
+++ b/man/MeasureRegr.Rd
@@ -28,17 +28,17 @@ The default measure for regression is \code{\link[=mlr_measures_regr.mse]{regr.m
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/MeasureSimilarity.Rd
+++ b/man/MeasureSimilarity.Rd
@@ -42,17 +42,17 @@ bmr$aggregate(msrs(c("classif.ce", "sim.jaccard")))
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/PredictionClassif.Rd
+++ b/man/PredictionClassif.Rd
@@ -77,8 +77,8 @@ p$score(measures = msr("classif.ce"))
 }
 
 Other Prediction: 
-\code{\link{PredictionRegr}},
-\code{\link{Prediction}}
+\code{\link{Prediction}},
+\code{\link{PredictionRegr}}
 }
 \concept{Prediction}
 \section{Super class}{

--- a/man/PredictionRegr.Rd
+++ b/man/PredictionRegr.Rd
@@ -28,8 +28,8 @@ head(as.data.table(p))
 }
 
 Other Prediction: 
-\code{\link{PredictionClassif}},
-\code{\link{Prediction}}
+\code{\link{Prediction}},
+\code{\link{PredictionClassif}}
 }
 \concept{Prediction}
 \section{Super class}{

--- a/man/Resampling.Rd
+++ b/man/Resampling.Rd
@@ -90,16 +90,16 @@ tasks.
 }
 
 Other Resampling: 
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Public fields}{

--- a/man/Task.Rd
+++ b/man/Task.Rd
@@ -91,6 +91,7 @@ Other Task:
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -101,8 +102,7 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}
 \section{Public fields}{

--- a/man/TaskClassif.Rd
+++ b/man/TaskClassif.Rd
@@ -46,10 +46,11 @@ task$data(rows = 1:3, cols = task$feature_names[1:2])
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -60,8 +61,7 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}
 \section{Super classes}{

--- a/man/TaskGenerator.Rd
+++ b/man/TaskGenerator.Rd
@@ -20,6 +20,7 @@ e.g. \code{\link[=mlr_task_generators_xor]{xor}}.
 }
 
 Other TaskGenerator: 
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -28,8 +29,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Public fields}{

--- a/man/TaskRegr.Rd
+++ b/man/TaskRegr.Rd
@@ -36,10 +36,11 @@ task$data(rows = 1:3, cols = task$feature_names[1:2])
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -50,8 +51,7 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}
 \section{Super classes}{

--- a/man/TaskSupervised.Rd
+++ b/man/TaskSupervised.Rd
@@ -31,10 +31,11 @@ TaskSupervised$new("penguins", task_type = "classif", backend = palmerpenguins::
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -45,8 +46,7 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}
 \keyword{internal}

--- a/man/TaskUnsupervised.Rd
+++ b/man/TaskUnsupervised.Rd
@@ -27,10 +27,11 @@ TaskUnsupervised$new("penguins", task_type = "regr", backend = palmerpenguins::p
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -41,8 +42,7 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}
 \keyword{internal}

--- a/man/as_data_backend.Rd
+++ b/man/as_data_backend.Rd
@@ -56,8 +56,8 @@ e.g. SQL servers or \CRANpkg{duckdb}.
 }
 
 Other DataBackend: 
+\code{\link{DataBackend}},
 \code{\link{DataBackendDataTable}},
-\code{\link{DataBackendMatrix}},
-\code{\link{DataBackend}}
+\code{\link{DataBackendMatrix}}
 }
 \concept{DataBackend}

--- a/man/as_learner.Rd
+++ b/man/as_learner.Rd
@@ -10,7 +10,7 @@
 \usage{
 as_learner(x, ...)
 
-\method{as_learner}{Learner}(x, clone = FALSE, ...)
+\method{as_learner}{Learner}(x, clone = FALSE, discard_state = FALSE, ...)
 
 as_learners(x, ...)
 
@@ -27,6 +27,9 @@ Additional arguments.}
 
 \item{clone}{(\code{logical(1)})\cr
 If \code{TRUE}, ensures that the returned object is not the same as the input \code{x}.}
+
+\item{discard_state}{(\code{logical(1)})
+Whether to discard the state.}
 }
 \value{
 \link{Learner}.

--- a/man/mlr_learners.Rd
+++ b/man/mlr_learners.Rd
@@ -50,9 +50,9 @@ Other Dictionary:
 \code{\link{mlr_tasks}}
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},

--- a/man/mlr_learners_classif.debug.Rd
+++ b/man/mlr_learners_classif.debug.Rd
@@ -102,15 +102,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_learners_classif.featureless.Rd
+++ b/man/mlr_learners_classif.featureless.Rd
@@ -68,15 +68,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_learners_classif.rpart.Rd
+++ b/man/mlr_learners_classif.rpart.Rd
@@ -82,15 +82,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_regr.debug}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_learners_regr.debug.Rd
+++ b/man/mlr_learners_regr.debug.Rd
@@ -75,15 +75,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_learners_regr.featureless.Rd
+++ b/man/mlr_learners_regr.featureless.Rd
@@ -57,15 +57,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
-\code{\link{mlr_learners_regr.rpart}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.rpart}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_learners_regr.rpart.Rd
+++ b/man/mlr_learners_regr.rpart.Rd
@@ -82,15 +82,15 @@ for established default tuning spaces.
 }
 
 Other Learner: 
+\code{\link{Learner}},
 \code{\link{LearnerClassif}},
 \code{\link{LearnerRegr}},
-\code{\link{Learner}},
+\code{\link{mlr_learners}},
 \code{\link{mlr_learners_classif.debug}},
 \code{\link{mlr_learners_classif.featureless}},
 \code{\link{mlr_learners_classif.rpart}},
 \code{\link{mlr_learners_regr.debug}},
-\code{\link{mlr_learners_regr.featureless}},
-\code{\link{mlr_learners}}
+\code{\link{mlr_learners_regr.featureless}}
 }
 \concept{Learner}
 \section{Super classes}{

--- a/man/mlr_measures.Rd
+++ b/man/mlr_measures.Rd
@@ -50,10 +50,10 @@ Other Dictionary:
 \code{\link{mlr_tasks}}
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},

--- a/man/mlr_measures_aic.Rd
+++ b/man/mlr_measures_aic.Rd
@@ -55,17 +55,17 @@ msr("aic")
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_measures_bic.Rd
+++ b/man/mlr_measures_bic.Rd
@@ -53,17 +53,17 @@ Empty ParamSet
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_measures_classif.acc.Rd
+++ b/man/mlr_measures_classif.acc.Rd
@@ -61,11 +61,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -80,10 +80,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.bacc}},

--- a/man/mlr_measures_classif.auc.Rd
+++ b/man/mlr_measures_classif.auc.Rd
@@ -62,11 +62,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -81,21 +81,21 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.bbrier}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -104,10 +104,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.bacc.Rd
+++ b/man/mlr_measures_classif.bacc.Rd
@@ -71,11 +71,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -90,10 +90,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.bbrier.Rd
+++ b/man/mlr_measures_classif.bbrier.Rd
@@ -68,11 +68,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -87,21 +87,21 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -110,10 +110,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.ce.Rd
+++ b/man/mlr_measures_classif.ce.Rd
@@ -61,11 +61,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -80,10 +80,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.costs.Rd
+++ b/man/mlr_measures_classif.costs.Rd
@@ -76,17 +76,17 @@ rr$aggregate(m)
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 
 Other classification measures: 
 \code{\link{mlr_measures_classif.acc}},
@@ -97,11 +97,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -116,10 +116,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.dor.Rd
+++ b/man/mlr_measures_classif.dor.Rd
@@ -63,11 +63,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -82,21 +82,21 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
 \code{\link{mlr_measures_classif.bbrier}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -105,10 +105,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fbeta.Rd
+++ b/man/mlr_measures_classif.fbeta.Rd
@@ -68,11 +68,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -87,21 +87,21 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
 \code{\link{mlr_measures_classif.bbrier}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -110,10 +110,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fdr.Rd
+++ b/man/mlr_measures_classif.fdr.Rd
@@ -63,11 +63,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -82,21 +82,21 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
 \code{\link{mlr_measures_classif.bbrier}},
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -105,10 +105,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fn.Rd
+++ b/man/mlr_measures_classif.fn.Rd
@@ -62,8 +62,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.fdr}},
 \code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -78,10 +78,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -91,8 +91,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.fdr}},
 \code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -101,10 +101,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fnr.Rd
+++ b/man/mlr_measures_classif.fnr.Rd
@@ -67,8 +67,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.fdr}},
 \code{\link{mlr_measures_classif.fn}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -96,8 +96,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.fdr}},
 \code{\link{mlr_measures_classif.fn}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fomr.Rd
+++ b/man/mlr_measures_classif.fomr.Rd
@@ -64,10 +64,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
-\code{\link{mlr_measures_classif.fpr}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -82,10 +82,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -93,10 +93,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
-\code{\link{mlr_measures_classif.fpr}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -105,10 +105,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fp.Rd
+++ b/man/mlr_measures_classif.fp.Rd
@@ -59,8 +59,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
 \code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
@@ -77,10 +77,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -88,8 +88,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
 \code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
@@ -100,10 +100,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.fpr.Rd
+++ b/man/mlr_measures_classif.fpr.Rd
@@ -65,8 +65,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
 \code{\link{mlr_measures_classif.fp}},
 \code{\link{mlr_measures_classif.logloss}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,8 +94,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
 \code{\link{mlr_measures_classif.fp}},
 \code{\link{mlr_measures_classif.mcc}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.logloss.Rd
+++ b/man/mlr_measures_classif.logloss.Rd
@@ -63,11 +63,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
 \code{\link{mlr_measures_classif.mauc_aunp}},
@@ -81,10 +81,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mauc_au1p.Rd
+++ b/man/mlr_measures_classif.mauc_au1p.Rd
@@ -80,11 +80,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
 \code{\link{mlr_measures_classif.mauc_aunp}},
@@ -98,10 +98,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mauc_au1u.Rd
+++ b/man/mlr_measures_classif.mauc_au1u.Rd
@@ -80,11 +80,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_aunp}},
@@ -98,10 +98,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mauc_aunp.Rd
+++ b/man/mlr_measures_classif.mauc_aunp.Rd
@@ -80,11 +80,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -98,10 +98,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mauc_aunu.Rd
+++ b/man/mlr_measures_classif.mauc_aunu.Rd
@@ -80,11 +80,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -98,10 +98,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mbrier.Rd
+++ b/man/mlr_measures_classif.mbrier.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other multiclass classification measures: 
 \code{\link{mlr_measures_classif.acc}},

--- a/man/mlr_measures_classif.mcc.Rd
+++ b/man/mlr_measures_classif.mcc.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
 \code{\link{mlr_measures_classif.prauc}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.npv.Rd
+++ b/man/mlr_measures_classif.npv.Rd
@@ -64,11 +64,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -82,10 +82,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -93,11 +93,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.ppv}},
 \code{\link{mlr_measures_classif.prauc}},
@@ -105,10 +105,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.ppv.Rd
+++ b/man/mlr_measures_classif.ppv.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.prauc}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.prauc.Rd
+++ b/man/mlr_measures_classif.prauc.Rd
@@ -64,11 +64,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -82,10 +82,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -93,11 +93,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -105,10 +105,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.precision.Rd
+++ b/man/mlr_measures_classif.precision.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.recall.Rd
+++ b/man/mlr_measures_classif.recall.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.sensitivity.Rd
+++ b/man/mlr_measures_classif.sensitivity.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.specificity.Rd
+++ b/man/mlr_measures_classif.specificity.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -83,10 +83,10 @@ Other classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -106,10 +106,10 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.precision}},
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tnr}},
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.tn.Rd
+++ b/man/mlr_measures_classif.tn.Rd
@@ -59,11 +59,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -79,8 +79,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
 \code{\link{mlr_measures_classif.tnr}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -88,11 +88,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -102,8 +102,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
 \code{\link{mlr_measures_classif.tnr}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.tnr.Rd
+++ b/man/mlr_measures_classif.tnr.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -85,8 +85,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
 \code{\link{mlr_measures_classif.auc}},
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -108,8 +108,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
 \code{\link{mlr_measures_classif.tn}},
-\code{\link{mlr_measures_classif.tpr}},
-\code{\link{mlr_measures_classif.tp}}
+\code{\link{mlr_measures_classif.tp}},
+\code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}
 \concept{classification measures}

--- a/man/mlr_measures_classif.tp.Rd
+++ b/man/mlr_measures_classif.tp.Rd
@@ -59,11 +59,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -78,8 +78,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
+\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tpr}}
 
 Other binary classification measures: 
@@ -88,11 +88,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -101,8 +101,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
+\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tpr}}
 }
 \concept{binary classification measures}

--- a/man/mlr_measures_classif.tpr.Rd
+++ b/man/mlr_measures_classif.tpr.Rd
@@ -65,11 +65,11 @@ Other classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.logloss}},
 \code{\link{mlr_measures_classif.mauc_au1p}},
 \code{\link{mlr_measures_classif.mauc_au1u}},
@@ -84,8 +84,8 @@ Other classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
+\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tp}}
 
 Other binary classification measures: 
@@ -94,11 +94,11 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.dor}},
 \code{\link{mlr_measures_classif.fbeta}},
 \code{\link{mlr_measures_classif.fdr}},
-\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fn}},
+\code{\link{mlr_measures_classif.fnr}},
 \code{\link{mlr_measures_classif.fomr}},
-\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.fp}},
+\code{\link{mlr_measures_classif.fpr}},
 \code{\link{mlr_measures_classif.mcc}},
 \code{\link{mlr_measures_classif.npv}},
 \code{\link{mlr_measures_classif.ppv}},
@@ -107,8 +107,8 @@ Other binary classification measures:
 \code{\link{mlr_measures_classif.recall}},
 \code{\link{mlr_measures_classif.sensitivity}},
 \code{\link{mlr_measures_classif.specificity}},
-\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tn}},
+\code{\link{mlr_measures_classif.tnr}},
 \code{\link{mlr_measures_classif.tp}}
 }
 \concept{binary classification measures}

--- a/man/mlr_measures_debug_classif.Rd
+++ b/man/mlr_measures_debug_classif.Rd
@@ -60,17 +60,17 @@ rr$score(measure)
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_elapsed_time}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_measures_elapsed_time.Rd
+++ b/man/mlr_measures_elapsed_time.Rd
@@ -51,17 +51,17 @@ Empty ParamSet
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_measures_oob_error.Rd
+++ b/man/mlr_measures_oob_error.Rd
@@ -50,17 +50,17 @@ Empty ParamSet
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
-\code{\link{mlr_measures_selected_features}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_selected_features}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_measures_selected_features.Rd
+++ b/man/mlr_measures_selected_features.Rd
@@ -64,17 +64,17 @@ scores[, c("iteration", "selected_features")]
 }
 
 Other Measure: 
+\code{\link{Measure}},
 \code{\link{MeasureClassif}},
 \code{\link{MeasureRegr}},
 \code{\link{MeasureSimilarity}},
-\code{\link{Measure}},
+\code{\link{mlr_measures}},
 \code{\link{mlr_measures_aic}},
 \code{\link{mlr_measures_bic}},
 \code{\link{mlr_measures_classif.costs}},
 \code{\link{mlr_measures_debug_classif}},
 \code{\link{mlr_measures_elapsed_time}},
-\code{\link{mlr_measures_oob_error}},
-\code{\link{mlr_measures}}
+\code{\link{mlr_measures_oob_error}}
 }
 \concept{Measure}
 \section{Super class}{

--- a/man/mlr_resamplings.Rd
+++ b/man/mlr_resamplings.Rd
@@ -47,8 +47,8 @@ Other Dictionary:
 Other Resampling: 
 \code{\link{Resampling}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},

--- a/man/mlr_resamplings_bootstrap.Rd
+++ b/man/mlr_resamplings_bootstrap.Rd
@@ -66,15 +66,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
-\code{\link{mlr_resamplings_custom_cv}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_custom.Rd
+++ b/man/mlr_resamplings_custom.Rd
@@ -43,6 +43,7 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
 \code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
@@ -50,8 +51,7 @@ Other Resampling:
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -54,6 +54,7 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
 \code{\link{mlr_resamplings_custom}},
 \code{\link{mlr_resamplings_cv}},
@@ -61,8 +62,7 @@ Other Resampling:
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_cv.Rd
+++ b/man/mlr_resamplings_cv.Rd
@@ -62,15 +62,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_holdout.Rd
+++ b/man/mlr_resamplings_holdout.Rd
@@ -63,15 +63,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_insample.Rd
+++ b/man/mlr_resamplings_insample.Rd
@@ -44,15 +44,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_loo}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_loo.Rd
+++ b/man/mlr_resamplings_loo.Rd
@@ -66,15 +66,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_repeated_cv.Rd
+++ b/man/mlr_resamplings_repeated_cv.Rd
@@ -73,15 +73,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
-\code{\link{mlr_resamplings_subsampling}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_resamplings_subsampling.Rd
+++ b/man/mlr_resamplings_subsampling.Rd
@@ -65,15 +65,15 @@ tasks.
 
 Other Resampling: 
 \code{\link{Resampling}},
+\code{\link{mlr_resamplings}},
 \code{\link{mlr_resamplings_bootstrap}},
-\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_custom}},
+\code{\link{mlr_resamplings_custom_cv}},
 \code{\link{mlr_resamplings_cv}},
 \code{\link{mlr_resamplings_holdout}},
 \code{\link{mlr_resamplings_insample}},
 \code{\link{mlr_resamplings_loo}},
-\code{\link{mlr_resamplings_repeated_cv}},
-\code{\link{mlr_resamplings}}
+\code{\link{mlr_resamplings_repeated_cv}}
 }
 \concept{Resampling}
 \section{Super class}{

--- a/man/mlr_task_generators_2dnormals.Rd
+++ b/man/mlr_task_generators_2dnormals.Rd
@@ -45,6 +45,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
 \code{\link{mlr_task_generators_friedman1}},
@@ -52,8 +53,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_cassini.Rd
+++ b/man/mlr_task_generators_cassini.Rd
@@ -45,6 +45,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_circle}},
 \code{\link{mlr_task_generators_friedman1}},
@@ -52,8 +53,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_circle.Rd
+++ b/man/mlr_task_generators_circle.Rd
@@ -44,6 +44,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_friedman1}},
@@ -51,8 +52,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_friedman1.Rd
+++ b/man/mlr_task_generators_friedman1.Rd
@@ -41,6 +41,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -48,8 +49,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_moons.Rd
+++ b/man/mlr_task_generators_moons.Rd
@@ -44,6 +44,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -51,8 +52,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_simplex.Rd
+++ b/man/mlr_task_generators_simplex.Rd
@@ -49,6 +49,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -56,8 +57,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_moons}},
 \code{\link{mlr_task_generators_smiley}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_smiley.Rd
+++ b/man/mlr_task_generators_smiley.Rd
@@ -44,6 +44,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -51,8 +52,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_moons}},
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_spirals.Rd
+++ b/man/mlr_task_generators_spirals.Rd
@@ -44,6 +44,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -51,8 +52,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_moons}},
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
-\code{\link{mlr_task_generators_xor}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_xor}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_task_generators_xor.Rd
+++ b/man/mlr_task_generators_xor.Rd
@@ -43,6 +43,7 @@ str(task$data())
 
 Other TaskGenerator: 
 \code{\link{TaskGenerator}},
+\code{\link{mlr_task_generators}},
 \code{\link{mlr_task_generators_2dnormals}},
 \code{\link{mlr_task_generators_cassini}},
 \code{\link{mlr_task_generators_circle}},
@@ -50,8 +51,7 @@ Other TaskGenerator:
 \code{\link{mlr_task_generators_moons}},
 \code{\link{mlr_task_generators_simplex}},
 \code{\link{mlr_task_generators_smiley}},
-\code{\link{mlr_task_generators_spirals}},
-\code{\link{mlr_task_generators}}
+\code{\link{mlr_task_generators_spirals}}
 }
 \concept{TaskGenerator}
 \section{Super class}{

--- a/man/mlr_tasks.Rd
+++ b/man/mlr_tasks.Rd
@@ -67,11 +67,11 @@ Other Dictionary:
 \code{\link{mlr_task_generators}}
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},

--- a/man/mlr_tasks_boston_housing.Rd
+++ b/man/mlr_tasks_boston_housing.Rd
@@ -49,11 +49,12 @@ tsk("boston_housing")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
 \code{\link{mlr_tasks_iris}},
@@ -63,7 +64,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_breast_cancer.Rd
+++ b/man/mlr_tasks_breast_cancer.Rd
@@ -55,11 +55,12 @@ tsk("breast_cancer")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_german_credit}},
 \code{\link{mlr_tasks_iris}},
@@ -69,7 +70,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_german_credit.Rd
+++ b/man/mlr_tasks_german_credit.Rd
@@ -79,11 +79,12 @@ Reports in Mathematics, Physics and Chemistry 4, Department II, Beuth University
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_iris}},
@@ -93,7 +94,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_iris.Rd
+++ b/man/mlr_tasks_iris.Rd
@@ -56,11 +56,12 @@ tsk("iris")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -70,7 +71,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_mtcars.Rd
+++ b/man/mlr_tasks_mtcars.Rd
@@ -49,11 +49,12 @@ tsk("mtcars")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -63,7 +64,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_penguins.Rd
+++ b/man/mlr_tasks_penguins.Rd
@@ -68,11 +68,12 @@ Gorman KB, Williams TD, Fraser WR (2014).
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -82,7 +83,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_pima.Rd
+++ b/man/mlr_tasks_pima.Rd
@@ -49,11 +49,12 @@ tsk("pima")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -63,7 +64,6 @@ Other Task:
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_sonar.Rd
+++ b/man/mlr_tasks_sonar.Rd
@@ -49,11 +49,12 @@ tsk("sonar")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -63,7 +64,6 @@ Other Task:
 \code{\link{mlr_tasks_pima}},
 \code{\link{mlr_tasks_spam}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_spam.Rd
+++ b/man/mlr_tasks_spam.Rd
@@ -67,11 +67,12 @@ Dua, Dheeru, Graff, Casey (2017).
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -81,7 +82,6 @@ Other Task:
 \code{\link{mlr_tasks_pima}},
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_wine.Rd
+++ b/man/mlr_tasks_wine.Rd
@@ -62,11 +62,12 @@ Dua, Dheeru, Graff, Casey (2017).
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -76,7 +77,6 @@ Other Task:
 \code{\link{mlr_tasks_pima}},
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
-\code{\link{mlr_tasks_zoo}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_zoo}}
 }
 \concept{Task}

--- a/man/mlr_tasks_zoo.Rd
+++ b/man/mlr_tasks_zoo.Rd
@@ -49,11 +49,12 @@ tsk("zoo")
 }
 
 Other Task: 
+\code{\link{Task}},
 \code{\link{TaskClassif}},
 \code{\link{TaskRegr}},
 \code{\link{TaskSupervised}},
 \code{\link{TaskUnsupervised}},
-\code{\link{Task}},
+\code{\link{mlr_tasks}},
 \code{\link{mlr_tasks_boston_housing}},
 \code{\link{mlr_tasks_breast_cancer}},
 \code{\link{mlr_tasks_german_credit}},
@@ -63,7 +64,6 @@ Other Task:
 \code{\link{mlr_tasks_pima}},
 \code{\link{mlr_tasks_sonar}},
 \code{\link{mlr_tasks_spam}},
-\code{\link{mlr_tasks_wine}},
-\code{\link{mlr_tasks}}
+\code{\link{mlr_tasks_wine}}
 }
 \concept{Task}

--- a/tests/testthat/test_as_learner.R
+++ b/tests/testthat/test_as_learner.R
@@ -10,3 +10,14 @@ test_that("as_learner conversion", {
   expect_list(as_learners(learner), types = "Learner")
   expect_list(as_learners(list(learner)), types = "Learner")
 })
+
+test_that("discard_state", {
+  learner = lrn("classif.rpart")$train(tsk("iris"))
+  learner2 = as_learner(learner, clone = TRUE, discard_state = TRUE)
+  expect_true(is.null(learner2$state))
+  expect_false(is.null(learner$state))
+
+  learner3 = lrn("classif.rpart")
+  as_learner(learner3, clone = FALSE, discard_state = TRUE)
+  expect_true(is.null(learner3$state))
+})

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -156,3 +156,18 @@ test_that("as_resample_result works for result data", {
   rr2 = as_resample_result(result_data)
   expect_class(rr2, "ResampleResult")
 })
+
+test_that("does not unnecessarily clone state", {
+  task = tsk("iris")
+  learner = R6Class("LearnerTest", inherit = LearnerClassifDebug, private = list(
+    deep_clone = function(name, value) {
+      if (name == "state" && !is.null(value)) {
+        stop("Buggy bug bug")
+      } else {
+        super$deep_clone(name, value)
+      }
+    }
+  ))$new()
+  learner$train(task)
+  expect_resample_result(resample(task, learner, rsmp("holdout")))
+})


### PR DESCRIPTION
the state is overwritten anyway later.

This matters for Learners that properly implement deep cloning.
For torch learners this can be expensive and should be avoided.