### PR TITLE
feat(marshaling): also marshal during predict

### DIFF
--- a/R/Learner.R
+++ b/R/Learner.R
@@ -280,7 +280,7 @@ Learner = R6Class("Learner",
         stopf("Cannot predict, Learner '%s' has not been trained yet", self$id)
       }
 
-      # we need to marshal for call-r prediction and parallel prediction, but we we afterwards we reset the model
+      # we need to marshal for call-r prediction and parallel prediction, but afterwards we reset the model
       # to it original state
       model_was_marshaled = is_marshaled_model(self$model)
       on.exit({

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -280,13 +280,23 @@ Learner = R6Class("Learner",
         stopf("Cannot predict, Learner '%s' has not been trained yet", self$id)
       }
 
-      if (is_marshaled_model(self$model)) {
-        stopf("Cannot predict, Learner '%s' has not been unmarshaled yet", self$id)
-      }
+      # we need to marshal for call-r prediction and parallel prediction, but we we afterwards we reset the model
+      # to it original state
+      model_was_marshaled = is_marshaled_model(self$model)
+      on.exit({
+        if (model_was_marshaled) {
+          self$model = marshal_model(self$model, inplace = TRUE)
+        } else {
+          self$model = unmarshal_model(self$model, inplace = TRUE)
+        }
+      }, add = TRUE)
 
+      # we only have to marshal here for the parallel prediction case, because learner_predict() handles the
+      # marshaling for call-r encapsulation itself
       if (isTRUE(self$parallel_predict) && nbrOfWorkers() > 1L) {
         row_ids = row_ids %??% task$row_ids
         chunked = chunk_vector(row_ids, n_chunks = nbrOfWorkers(), shuffle = FALSE)
+        self$model = marshal_model(self$model, inplace = TRUE)
         pdata = future.apply::future_lapply(chunked,
           learner_predict, learner = self, task = task,
           future.globals = FALSE, future.seed = TRUE)
@@ -294,6 +304,7 @@ Learner = R6Class("Learner",
       } else {
         pdata = learner_predict(self, task, row_ids)
       }
+
 
       if (is.null(pdata)) {
         return(NULL)

--- a/R/LearnerClassifDebug.R
+++ b/R/LearnerClassifDebug.R
@@ -25,6 +25,7 @@
 #'    \item{x:}{Numeric tuning parameter. Has no effect.}
 #'    \item{iter:}{Integer parameter for testing hotstarting.}
 #'    \item{count_marshaling:}{If `TRUE`, `marshal_model` will increase the `marshal_count` by 1 each time it is called. The default is `FALSE`.}
+#'    \item{check_pid:}{If `TRUE`, the `$predict()` function will throw an error if the model was not unmarshaled in the same session that is used for prediction.)}
 #' }
 #' Note that segfaults may not be triggered reliably on your operating system.
 #' Also note that if they work as intended, they will tear down your R session immediately!
@@ -67,7 +68,8 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
         warning_train        = p_dbl(0, 1, default = 0, tags = "train"),
         x                    = p_dbl(0, 1, tags = "train"),
         iter                 = p_int(1, default = 1, tags = c("train", "hotstart")),
-        count_marshaling     = p_lgl(default = FALSE, tags = "train")
+        count_marshaling     = p_lgl(default = FALSE, tags = "train"),
+        check_pid            = p_lgl(default = TRUE, tags = "train")
       )
       super$initialize(
         id = "classif.debug",
@@ -134,6 +136,10 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
         model$task_train = task$clone(deep = TRUE)
       }
 
+      if (pv$check_pid %??% FALSE) {
+        model$marshal_pid = Sys.getpid()
+      }
+
       if (isTRUE(pv$count_marshaling)) {
         model$marshal_count = 0L
       }
@@ -142,6 +148,9 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
     },
 
     .predict = function(task) {
+      if (!is.null(self$model$marshal_pid) && self$model$marshal_pid != Sys.getpid()) {
+        stopf("Model was not unmarshaled correctly")
+      }
       n = task$nrow
       pv = self$param_set$get_values(tags = "predict")
       roll = function(name) {
@@ -237,5 +246,9 @@ marshal_model.classif.debug_model = function(model, inplace = FALSE, ...) {
 #' @export
 #' @method unmarshal_model classif.debug_model_marshaled
 unmarshal_model.classif.debug_model_marshaled = function(model, inplace = FALSE, ...) {
-  model$marshaled
+  unmarshaled = model$marshaled
+  if (!is.null(unmarshaled$marshal_pid)) {
+    unmarshaled$marshal_pid = Sys.getpid()
+  }
+  unmarshaled
 }

--- a/R/resample.R
+++ b/R/resample.R
@@ -130,6 +130,9 @@ resample = function(task, learner, resampling, store_models = FALSE, store_backe
 
   result_data = ResultData$new(data, store_backends = store_backends)
 
+  # the worker already ensures that models are sent back in marshaled form if unmarshal = FALSE, so we don't have
+  # to do anything in this case. This allows us to minimize the amount of marshaling in those situtions where
+  # the model is available in both states on the worker
   if (unmarshal && store_models) {
     result_data$unmarshal()
   }

--- a/R/worker.R
+++ b/R/worker.R
@@ -275,7 +275,7 @@ workhorse = function(iteration, task, learner, resampling, param_values = NULL, 
   # predict for each set
   sets = sets[learner$predict_sets]
   pdatas = Map(function(set, row_ids) {
-    lg$debug("Creating Prediction for predict set '%se'", set)
+    lg$debug("Creating Prediction for predict set '%s'", set)
     learner_predict(learner, task, row_ids)
   }, set = names(sets), row_ids = sets)
   pdatas = discard(pdatas, is.null)

--- a/R/worker.R
+++ b/R/worker.R
@@ -268,6 +268,7 @@ workhorse = function(iteration, task, learner, resampling, param_values = NULL, 
 
   # process the model so it can be used for prediction (e.g. marshal for callr prediction), but also
   # keep a copy of the model in current form in case this is the format that we want to send back to the main process
+  # and not the format that we need for prediction
   model_copy_or_null = process_model_before_predict(
     learner = learner, store_models = store_models, is_sequential = is_sequential, unmarshal = unmarshal
   )
@@ -306,7 +307,6 @@ process_model_before_predict = function(learner, store_models, is_sequential, un
   # the only scenario in which we keep a copy is when we now have the model in the correct form but need to transform
   # it for prediction
   keep_copy = store_models & (currently_marshaled == final_needs_marshaling) && (currently_marshaled != predict_needs_marshaling)
-  # This is because learner_predict does it in-place, but here we
 
   if (!keep_copy) {
     # here we either

--- a/inst/testthat/helper_expectations.R
+++ b/inst/testthat/helper_expectations.R
@@ -426,11 +426,6 @@ expect_marshalable_learner = function(learner, task) {
   }
   testthat::expect_equal(mlr3::is_marshaled_model(learner$model), learner$marshaled)
 
-  if (learner$marshaled) {
-    # cannot predict with marshaled learner
-    testthat::expect_error(learner$predict(task), "has not been unmarshaled")
-  }
-
   # unmarshaling works
   testthat::expect_invisible(learner$unmarshal())
   # can predict after unmarshaling

--- a/man-roxygen/param_unmarshal.R
+++ b/man-roxygen/param_unmarshal.R
@@ -1,5 +1,4 @@
 #' @param unmarshal [`Learner`]\cr
 #'   Whether to unmarshal learners that were marshaled during the execution.
-#'   Setting this to `FALSE` does not guarantee that the learners are marshaled.
-#'   For example, with sequential execution and no encapsulation, marshaling is not necessary.
-#'   If you want to ensure that all learners are in marshaled form, you need to call `$marshal()` on the result object.
+#'   If `TRUE` all learners are in unmarshaled form.
+#'   If `FALSE`, all learners that need marshaling will be in marshaled form.

--- a/man-roxygen/param_unmarshal.R
+++ b/man-roxygen/param_unmarshal.R
@@ -1,4 +1,4 @@
 #' @param unmarshal [`Learner`]\cr
 #'   Whether to unmarshal learners that were marshaled during the execution.
-#'   If `TRUE` all learners are in unmarshaled form.
-#'   If `FALSE`, all learners that need marshaling will be in marshaled form.
+#'   If `TRUE` all models are stored in unmarshaled form.
+#'   If `FALSE`, all learners (that need marshaling) are stored in marshaled form.

--- a/man/benchmark.Rd
+++ b/man/benchmark.Rd
@@ -61,8 +61,8 @@ Per default, all input objects are cloned.}
 
 \item{unmarshal}{\code{\link{Learner}}\cr
 Whether to unmarshal learners that were marshaled during the execution.
-If \code{TRUE} all learners are in unmarshaled form.
-If \code{FALSE}, all learners that need marshaling will be in marshaled form.}
+If \code{TRUE} all models are stored in unmarshaled form.
+If \code{FALSE}, all learners (that need marshaling) are stored in marshaled form.}
 }
 \value{
 \link{BenchmarkResult}.

--- a/man/benchmark.Rd
+++ b/man/benchmark.Rd
@@ -61,9 +61,8 @@ Per default, all input objects are cloned.}
 
 \item{unmarshal}{\code{\link{Learner}}\cr
 Whether to unmarshal learners that were marshaled during the execution.
-Setting this to \code{FALSE} does not guarantee that the learners are marshaled.
-For example, with sequential execution and no encapsulation, marshaling is not necessary.
-If you want to ensure that all learners are in marshaled form, you need to call \verb{$marshal()} on the result object.}
+If \code{TRUE} all learners are in unmarshaled form.
+If \code{FALSE}, all learners that need marshaling will be in marshaled form.}
 }
 \value{
 \link{BenchmarkResult}.

--- a/man/mlr_learners_classif.debug.Rd
+++ b/man/mlr_learners_classif.debug.Rd
@@ -26,6 +26,7 @@ The following hyperparameters trigger the following actions:
 \item{x:}{Numeric tuning parameter. Has no effect.}
 \item{iter:}{Integer parameter for testing hotstarting.}
 \item{count_marshaling:}{If \code{TRUE}, \code{marshal_model} will increase the \code{marshal_count} by 1 each time it is called. The default is \code{FALSE}.}
+\item{check_pid:}{If \code{TRUE}, the \verb{$predict()} function will throw an error if the model was not unmarshaled in the same session that is used for prediction.)}
 }
 Note that segfaults may not be triggered reliably on your operating system.
 Also note that if they work as intended, they will tear down your R session immediately!
@@ -69,6 +70,7 @@ lrn("classif.debug")
    x \tab numeric \tab - \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
    iter \tab integer \tab 1 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
    count_marshaling \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
+   check_pid \tab logical \tab TRUE \tab TRUE, FALSE \tab - \cr
 }
 }
 

--- a/man/resample.Rd
+++ b/man/resample.Rd
@@ -62,9 +62,8 @@ Per default, all input objects are cloned.}
 
 \item{unmarshal}{\code{\link{Learner}}\cr
 Whether to unmarshal learners that were marshaled during the execution.
-Setting this to \code{FALSE} does not guarantee that the learners are marshaled.
-For example, with sequential execution and no encapsulation, marshaling is not necessary.
-If you want to ensure that all learners are in marshaled form, you need to call \verb{$marshal()} on the result object.}
+If \code{TRUE} all learners are in unmarshaled form.
+If \code{FALSE}, all learners that need marshaling will be in marshaled form.}
 }
 \value{
 \link{ResampleResult}.

--- a/man/resample.Rd
+++ b/man/resample.Rd
@@ -62,8 +62,8 @@ Per default, all input objects are cloned.}
 
 \item{unmarshal}{\code{\link{Learner}}\cr
 Whether to unmarshal learners that were marshaled during the execution.
-If \code{TRUE} all learners are in unmarshaled form.
-If \code{FALSE}, all learners that need marshaling will be in marshaled form.}
+If \code{TRUE} all models are stored in unmarshaled form.
+If \code{FALSE}, all learners (that need marshaling) are stored in marshaled form.}
 }
 \value{
 \link{ResampleResult}.

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -348,3 +348,7 @@ test_that("marshal state", {
   expect_true(is_marshaled_model(sm))
   expect_equal(state, unmarshal_model(marshal_model(state)))
 })
+
+test_that("parallel predict and marshaling", {
+
+})

--- a/tests/testthat/test_Learner.R
+++ b/tests/testthat/test_Learner.R
@@ -349,6 +349,37 @@ test_that("marshal state", {
   expect_equal(state, unmarshal_model(marshal_model(state)))
 })
 
-test_that("parallel predict and marshaling", {
+test_that("model is marshaled during parallel predict", {
+  # by setting check_pid = TRUE, we ensure that unmarshal_model() sets the process id to the current
+  # id. LearnerClassifDebug then checks during `.predict()`, whether the marshal_id of the model is equal to the current process id and errs if this is not the case.
+  task = tsk("iris")
+  learner = lrn("classif.debug", check_pid = TRUE)
+  learner$train(task)
+  learner$parallel_predict = TRUE
+  pred = with_future(future::multisession, {
+    learner$predict(task)
+  })
+  expect_class(pred, "Prediction")
+})
 
+test_that("model is marshaled during callr prediction", {
+  # by setting check_pid = TRUE, we ensure that unmarshal_model() sets the process id to the current
+  # id. LearnerClassifDebug then checks during `.predict()`, whether the marshal_id of the model is equal to the current process id and errs if this is not the case.
+  task = tsk("iris")
+  learner = lrn("classif.debug", check_pid = TRUE, encapsulate = c(predict = "callr"))
+  learner$train(task)
+  pred = learner$predict(task)
+  expect_class(pred, "Prediction")
+})
+
+test_that("predict leaves marshaling status as-is", {
+  task = tsk("iris")
+  learner = lrn("classif.debug", check_pid = TRUE, encapsulate = c(predict = "callr"))
+  learner$train(task)
+  learner$marshal()
+  expect_class(learner$predict(task), "Prediction")
+  expect_true(learner$marshaled)
+  learner$unmarshal()
+  expect_class(learner$predict(task), "Prediction")
+  expect_false(learner$marshaled)
 })

--- a/tests/testthat/test_marshal.R
+++ b/tests/testthat/test_marshal.R
@@ -39,7 +39,6 @@ test_that("marshaling for LearnerClassif", {
   expect_false(learner$marshaled)
   learner$marshal()
   expect_true(learner$marshaled)
-  expect_error(learner$predict(task), "has not been unmarshaled")
   learner$unmarshal()
   expect_learner(learner, task)
 })

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -163,7 +163,7 @@ test_that("encapsulation triggers marshaling correctly", {
   task = tsk("iris")
   resampling = rsmp("holdout")
   rr1 = resample(task, learner1, resampling, store_models = TRUE, unmarshal = FALSE)
-  expect_true(rr1$learners[[1]]$marshaled)
+  expect_false(rr1$learners[[1]]$marshaled)
   rr2 = resample(task, learner2, resampling, store_models = TRUE, unmarshal = FALSE)
   expect_false(rr2$learners[[1]]$marshaled)
 })
@@ -268,7 +268,7 @@ test_that("marshaling does not change class of learner state when reassembling",
 })
 
 test_that("marshaled model is sent back, when unmarshal is FALSE, sequential exec and callr", {
-  learner = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr"))
+  learner = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr", predict = "callr"))
   rr = resample(tsk("iris"), learner, rsmp("holdout"), store_models = TRUE, unmarshal = FALSE)
   expect_true(rr$learners[[1L]]$marshaled)
 })

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -163,9 +163,9 @@ test_that("encapsulation triggers marshaling correctly", {
   task = tsk("iris")
   resampling = rsmp("holdout")
   rr1 = resample(task, learner1, resampling, store_models = TRUE, unmarshal = FALSE)
-  expect_false(rr1$learners[[1]]$marshaled)
+  expect_true(rr1$learners[[1]]$marshaled)
   rr2 = resample(task, learner2, resampling, store_models = TRUE, unmarshal = FALSE)
-  expect_false(rr2$learners[[1]]$marshaled)
+  expect_true(rr2$learners[[1]]$marshaled)
 })
 
 test_that("parallel execution automatically triggers marshaling", {

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -272,3 +272,64 @@ test_that("marshaled model is sent back, when unmarshal is FALSE, sequential exe
   rr = resample(tsk("iris"), learner, rsmp("holdout"), store_models = TRUE, unmarshal = FALSE)
   expect_true(rr$learners[[1L]]$marshaled)
 })
+
+test_that("callr during prediction triggers marshaling", {
+  learner1 = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "none", predict = "callr"))
+  learner2 = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr", predict = "callr"))
+
+  rr1 = with_future(future::multisession, {
+    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
+  })
+  l1 = rr1$learners[[1L]]
+  expect_true(l1$marshaled)
+  expect_equal(l1$model$marshaled$marshal_count, 1L)
+
+  rr2 = with_future(future::sequential, {
+    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
+  })
+  l2 = rr2$learners[[1L]]
+  expect_true(l2$marshaled)
+  expect_equal(l2$model$marshaled$marshal_count, 1L)
+
+  rr3 = with_future(future::multisession, {
+    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
+  })
+  l3 = rr3$learners[[1L]]
+  expect_true(l3$marshaled)
+  expect_equal(l3$model$marshaled$marshal_count, 1L)
+
+  rr4 = with_future(future::sequential, {
+    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
+  })
+  l4 = rr4$learners[[1L]]
+  expect_true(l4$marshaled)
+  expect_equal(l4$model$marshaled$marshal_count, 1L)
+
+  rr5 = with_future(future::multisession, {
+    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
+  })
+  l5 = rr5$learners[[1L]]
+  expect_false(l5$marshaled)
+  expect_equal(l5$model$marshal_count, 1L)
+
+  rr6 = with_future(future::sequential, {
+    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
+  })
+  l6 = rr6$learners[[1L]]
+  expect_false(l6$marshaled)
+  expect_equal(l6$model$marshal_count, 0L)
+
+  rr7 = with_future(future::multisession, {
+    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
+  })
+  l7 = rr7$learners[[1L]]
+  expect_false(l7$marshaled)
+  expect_equal(l7$model$marshal_count, 1L)
+
+  rr8 = with_future(future::sequential, {
+    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
+  })
+  l8 = rr8$learners[[1L]]
+  expect_false(l8$marshaled)
+  expect_equal(l8$model$marshal_count, 1L)
+})


### PR DESCRIPTION
Summary: 

* setting `unmarshal = FALSE` not ensures that all models are in unmarshaled form (`resample()`, `benchmark()`). This is just easier to reason about 
* models are now also marshaled for prediction, i.e. for callr encapsulation and parallel prediction (I made a wrong assumption + somehow did not properly test this assumption)
* the marshaling of models for prediction happens automatically during `Learner$predict()`, but the model will be restored to its state before prediction. 
* the logic for the marshaling in the worker was refactored and is now much easier to understand 
* The `LearnerClassifDebug` now got an argument called `check_pid` that is `FALSE` by default. If this is set to `TRUE`, the `unmarshal_model()` method for `model_classif_debug` sets the `marshal_pid` slot of the model. The private `$.predict()` method of `LearnerClassifDebug` then checks that the `marhsal_pid` is equal to `Sys.getpid()`. This lets us test that the unmarshaling is executed correctly for the prediction. 
