### PR TITLE
tests: remove unneded marshaling test

### DIFF
--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -517,42 +517,6 @@ test_that("properties are also checked on validation task", {
   expect_error(benchmark(benchmark_grid(task, learner, rsmp("holdout"))), "missing values")
 })
 
-test_that("parallel execution automatically triggers marshaling", {
-  learner = lrn("classif.debug", count_marshaling = TRUE)
-  task = tsk("iris")
-  resampling = rsmp("holdout")
-  design = benchmark_grid(task, learner, resampling)
-  bmr = with_future(future::multisession, {
-    benchmark(design, store_models = TRUE, unmarshal = TRUE)
-  })
-  expect_equal(bmr$resample_result(1)$learners[[1]]$model$marshal_count, 1)
-  expect_false(bmr$resample_result(1)$learners[[1]]$marshaled)
-})
-
-test_that("sequential execution does not trigger marshaling", {
-  learner = lrn("classif.debug", count_marshaling = TRUE)
-  task = tsk("iris")
-  resampling = rsmp("holdout")
-  design = benchmark_grid(task, learner, resampling)
-  bmr = with_future(future::sequential, {
-    benchmark(design, store_models = TRUE, unmarshal = TRUE)
-  })
-  expect_equal(bmr$resample_result(1)$learners[[1]]$model$marshal_count, 0)
-})
-
-test_that("parallel execution and callr marshal once", {
-  learner = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr"))
-  task = tsk("iris")
-  resampling = rsmp("holdout")
-  design = benchmark_grid(task, learner, resampling)
-  bmr = with_future(future::multisession, {
-    benchmark(design, store_models = TRUE, unmarshal = TRUE)
-  })
-  expect_equal(bmr$resample_result(1)$learners[[1]]$model$marshal_count, 1)
-  expect_false(bmr$resample_result(1)$learners[[1]]$marshaled)
-})
-
-
 test_that("unmarshal parameter is respected", {
   learner = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr"))
   task = tsk("iris")

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -373,65 +373,14 @@ test_that("can even use internal_valid predict set on learners that don't suppor
   rr = resample(task, lrn("regr.debug", predict_sets = "internal_valid"), rsmp("holdout"))
 })
 
-test_that("callr during prediction triggers marshaling", {
-  learner1 = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "none", predict = "callr"))
-  learner2 = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr", predict = "callr"))
-
+test_that("marshaling is called the necessary number of times", {
+  learner1 = lrn("classif.debug", count_marshaling = TRUE, encapsulate = c(train = "callr", predict = "callr"))
   rr1 = with_future(future::multisession, {
-    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
+    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
   })
   l1 = rr1$learners[[1L]]
-  expect_true(l1$marshaled)
-  expect_equal(l1$model$marshaled$marshal_count, 1L)
-
-  rr2 = with_future(future::sequential, {
-    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
-  })
-  l2 = rr2$learners[[1L]]
-  expect_true(l2$marshaled)
-  expect_equal(l2$model$marshaled$marshal_count, 1L)
-
-  rr3 = with_future(future::multisession, {
-    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
-  })
-  l3 = rr3$learners[[1L]]
-  expect_true(l3$marshaled)
-  expect_equal(l3$model$marshaled$marshal_count, 1L)
-
-  rr4 = with_future(future::sequential, {
-    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = FALSE, store_models = TRUE)
-  })
-  l4 = rr4$learners[[1L]]
-  expect_true(l4$marshaled)
-  expect_equal(l4$model$marshaled$marshal_count, 1L)
-
-  rr5 = with_future(future::multisession, {
-    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
-  })
-  l5 = rr5$learners[[1L]]
-  expect_false(l5$marshaled)
-  expect_equal(l5$model$marshal_count, 1L)
-
-  rr6 = with_future(future::sequential, {
-    resample(tsk("iris"), learner1, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
-  })
-  l6 = rr6$learners[[1L]]
-  expect_false(l6$marshaled)
-  expect_equal(l6$model$marshal_count, 0L)
-
-  rr7 = with_future(future::multisession, {
-    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
-  })
-  l7 = rr7$learners[[1L]]
-  expect_false(l7$marshaled)
-  expect_equal(l7$model$marshal_count, 1L)
-
-  rr8 = with_future(future::sequential, {
-    resample(tsk("iris"), learner2, rsmp("holdout"), unmarshal = TRUE, store_models = TRUE)
-  })
-  l8 = rr8$learners[[1L]]
-  expect_false(l8$marshaled)
-  expect_equal(l8$model$marshal_count, 1L)
+  expect_false(l1$marshaled)
+  expect_equal(l1$model$marshal_count, 1L)
 })
 
 test_that("obs_loss", {


### PR DESCRIPTION
This functionality is essentially the same as for resample() where there are also the same tests, so this can be removed

Fixes #1083