### PR TITLE
perf: use `data.table::%chin%`

### DIFF
--- a/R/DataBackendRename.R
+++ b/R/DataBackendRename.R
@@ -15,7 +15,7 @@ DataBackendRename = R6Class("DataBackendRename", inherit = DataBackend, cloneabl
       old = old[ii]
       new = new[ii]
 
-      if (self$primary_key %in% old) {
+      if (self$primary_key %chin% old) {
         stopf("Renaming the primary key is not supported")
       }
 

--- a/R/HotstartStack.R
+++ b/R/HotstartStack.R
@@ -202,9 +202,9 @@ calculate_cost = function(start_learner, learner, hotstart_id) {
   cost = learner$param_set$values[[hotstart_id]] - start_learner$param_set$values[[hotstart_id]]
   if (cost == 0) return(-1)
 
-  if ("hotstart_backward" %in% learner$properties && "hotstart_forward" %in% learner$properties) {
+  if ("hotstart_backward" %chin% learner$properties && "hotstart_forward" %chin% learner$properties) {
     if (cost < 0) 0 else cost
-  } else if ("hotstart_backward" %in% learner$properties) {
+  } else if ("hotstart_backward" %chin% learner$properties) {
     if (cost < 0) 0 else NA_real_
   } else {
     if (cost > 0) cost else NA_real_

--- a/R/LearnerClassifDebug.R
+++ b/R/LearnerClassifDebug.R
@@ -163,7 +163,7 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
       pv = self$param_set$get_values(tags = "train")
       pv$count_marshaling = pv$count_marshaling %??% FALSE
       roll = function(name) {
-        name %in% names(pv) && pv[[name]] > runif(1L)
+        name %chin% names(pv) && pv[[name]] > runif(1L)
       }
 
       if (!is.null(pv$sleep_train)) {
@@ -248,7 +248,7 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
       n = task$nrow
       pv = self$param_set$get_values(tags = "predict")
       roll = function(name) {
-        name %in% names(pv) && pv[[name]] > runif(1L)
+        name %chin% names(pv) && pv[[name]] > runif(1L)
       }
 
       if (!is.null(pv$sleep_predict)) {
@@ -281,7 +281,7 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
       response = prob = NULL
       missing_type = pv$predict_missing_type %??% "na"
 
-      if ("response" %in% self$predict_type) {
+      if ("response" %chin% self$predict_type) {
         response = rep.int(unclass(model$response), n)
         if (!is.null(pv$predict_missing)) {
           ii = sample.int(n, n * pv$predict_missing)
@@ -292,7 +292,7 @@ LearnerClassifDebug = R6Class("LearnerClassifDebug", inherit = LearnerClassif,
         }
       }
 
-      if ("prob" %in% self$predict_type) {
+      if ("prob" %chin% self$predict_type) {
         cl = task$class_names
         prob = matrix(runif(n * length(cl)), nrow = n)
         prob = prob / rowSums(prob)

--- a/R/LearnerClassifRpart.R
+++ b/R/LearnerClassifRpart.R
@@ -77,7 +77,7 @@ LearnerClassifRpart = R6Class("LearnerClassifRpart", inherit = LearnerClassif,
     .train = function(task) {
       pv = self$param_set$get_values(tags = "train")
       names(pv) = replace(names(pv), names(pv) == "keep_model", "model")
-      if ("weights" %in% task$properties) {
+      if ("weights" %chin% task$properties) {
         pv = insert_named(pv, list(weights = task$weights$weight))
       }
 
@@ -89,11 +89,11 @@ LearnerClassifRpart = R6Class("LearnerClassifRpart", inherit = LearnerClassif,
       newdata = task$data(cols = task$feature_names)
       response = prob = NULL
 
-      if ("response" %in% self$predict_type) {
+      if ("response" %chin% self$predict_type) {
         response = invoke(predict, self$model, newdata = newdata, type = "class",
           .opts = allow_partial_matching, .args = pv)
         response = unname(response)
-      } else if ("prob" %in% self$predict_type) {
+      } else if ("prob" %chin% self$predict_type) {
         prob = invoke(predict, self$model, newdata = newdata, type = "prob",
           .opts = allow_partial_matching, .args = pv)
         rownames(prob) = NULL

--- a/R/LearnerRegrRpart.R
+++ b/R/LearnerRegrRpart.R
@@ -77,7 +77,7 @@ LearnerRegrRpart = R6Class("LearnerRegrRpart", inherit = LearnerRegr,
     .train = function(task) {
       pv = self$param_set$get_values(tags = "train")
       names(pv) = replace(names(pv), names(pv) == "keep_model", "model")
-      if ("weights" %in% task$properties) {
+      if ("weights" %chin% task$properties) {
         pv = insert_named(pv, list(weights = task$weights$weight))
       }
 

--- a/R/Measure.R
+++ b/R/Measure.R
@@ -200,11 +200,11 @@ Measure = R6Class("Measure",
       # check should be added to assert_measure()
       # except when the checks are superfluous for rr$score() and bmr$score()
       # these checks should be added bellow
-      if ("requires_task" %in% self$properties && is.null(task)) {
+      if ("requires_task" %chin% self$properties && is.null(task)) {
         stopf("Measure '%s' requires a task", self$id)
       }
 
-      if ("requires_learner" %in% self$properties && is.null(learner)) {
+      if ("requires_learner" %chin% self$properties && is.null(learner)) {
         stopf("Measure '%s' requires a learner", self$id)
       }
 
@@ -212,7 +212,7 @@ Measure = R6Class("Measure",
         stopf("Measure '%s' incompatible with task type '%s'", self$id, prediction$task_type)
       }
 
-      if ("requires_train_set" %in% self$properties && is.null(train_set)) {
+      if ("requires_train_set" %chin% self$properties && is.null(train_set)) {
         stopf("Measure '%s' requires the train_set", self$id)
       }
 
@@ -258,7 +258,7 @@ Measure = R6Class("Measure",
     #' @template field_predict_sets
     predict_sets = function(rhs) {
       if (!missing(rhs)) {
-        private$.predict_sets = assert_subset(rhs, mlr_reflections$predict_sets, empty.ok = "requires_no_prediction" %in% self$properties)
+        private$.predict_sets = assert_subset(rhs, mlr_reflections$predict_sets, empty.ok = "requires_no_prediction" %chin% self$properties)
       }
       private$.predict_sets
     },
@@ -385,7 +385,7 @@ score_single_measure = function(measure, task, learner, train_set, prediction) {
 #' @noRd
 score_measures = function(obj, measures, reassemble = TRUE, view = NULL, iters = NULL) {
   reassemble_learners = reassemble ||
-    some(measures, function(m) any(c("requires_learner", "requires_model") %in% m$properties))
+    some(measures, function(m) any(c("requires_learner", "requires_model") %chin% m$properties))
   tab = get_private(obj)$.data$as_data_table(view = view, reassemble_learners = reassemble_learners, convert_predictions = FALSE)
 
   if (!is.null(iters)) {

--- a/R/PredictionClassif.R
+++ b/R/PredictionClassif.R
@@ -175,7 +175,7 @@ PredictionClassif = R6Class("PredictionClassif", inherit = Prediction,
 as.data.table.PredictionClassif = function(x, ...) { # nolint
   tab = as.data.table(x$data[c("row_ids", "truth", "response")])
 
-  if ("prob" %in% x$predict_types) {
+  if ("prob" %chin% x$predict_types) {
     prob = as.data.table(x$data$prob)
     setnames(prob, names(prob), paste0("prob.", names(prob)))
     tab = rcbind(tab, prob)

--- a/R/PredictionDataClassif.R
+++ b/R/PredictionDataClassif.R
@@ -132,11 +132,11 @@ create_empty_prediction_data.TaskClassif = function(task, learner) {
     truth = factor(character(), levels = cn)
   )
 
-  if ("response" %in% predict_types) {
+  if ("response" %chin% predict_types) {
     pdata$response = pdata$truth
   }
 
-  if ("prob" %in% predict_types) {
+  if ("prob" %chin% predict_types) {
     pdata$prob = matrix(numeric(), nrow = 0L, ncol = length(cn), dimnames = list(NULL, cn))
   }
 

--- a/R/PredictionDataRegr.R
+++ b/R/PredictionDataRegr.R
@@ -99,7 +99,7 @@ c.PredictionDataRegr = function(..., keep_duplicates = TRUE) { # nolint
   result = as.list(tab)
   result$quantiles = quantiles
 
-  if ("distr" %in% predict_types[[1L]]) {
+  if ("distr" %chin% predict_types[[1L]]) {
     require_namespaces("distr6", msg = "To predict probability distributions, please install %s")
     result$distr = do.call(c, map(dots, "distr"))
   }
@@ -137,15 +137,15 @@ create_empty_prediction_data.TaskRegr = function(task, learner) {
     truth = numeric()
   )
 
-  if ("response" %in% predict_types) {
+  if ("response" %chin% predict_types) {
     pdata$response = pdata$truth
   }
 
-  if ("se" %in% predict_types) {
+  if ("se" %chin% predict_types) {
     pdata$se = pdata$truth
   }
 
-  if ("distr" %in% predict_types) {
+  if ("distr" %chin% predict_types) {
     pdata$distr = list()
   }
 

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -61,7 +61,7 @@ PredictionRegr = R6Class("PredictionRegr", inherit = Prediction,
       self$data = pdata
       predict_types = intersect(names(mlr_reflections$learner_predict_types[["regr"]]), names(pdata))
       # response is in saved in quantiles matrix
-      if ("quantiles" %in% predict_types) predict_types = union(predict_types, "response")
+      if ("quantiles" %chin% predict_types) predict_types = union(predict_types, "response")
       self$predict_types = predict_types
       if (is.null(pdata$response)) private$.quantile_response = attr(quantiles, "response")
     }
@@ -94,7 +94,7 @@ PredictionRegr = R6Class("PredictionRegr", inherit = Prediction,
     #' Access the stored vector distribution.
     #' Requires package `distr6`(in repository \url{https://raphaels1.r-universe.dev}) .
     distr = function() {
-      if ("distr" %in% self$predict_types) {
+      if ("distr" %chin% self$predict_types) {
         require_namespaces("distr6", msg = "To predict probability distributions, please install %s")
       }
       return(self$data$distr)
@@ -111,12 +111,12 @@ PredictionRegr = R6Class("PredictionRegr", inherit = Prediction,
 as.data.table.PredictionRegr = function(x, ...) { # nolint
   tab = as.data.table(x$data[c("row_ids", "truth", "response", "se")])
 
-  if ("quantiles" %in% x$predict_types) {
+  if ("quantiles" %chin% x$predict_types) {
     tab = rcbind(tab, as.data.table(x$data$quantiles))
     set(tab, j = "response", value = x$response)
   }
 
-  if ("distr" %in% x$predict_types) {
+  if ("distr" %chin% x$predict_types) {
     require_namespaces("distr6", msg = "To predict probability distributions, please install %s")
     tab$distr = list(x$distr)
   }

--- a/R/Task.R
+++ b/R/Task.R
@@ -226,7 +226,7 @@ Task = R6Class("Task",
 
       # print additional columns as specified in reflections
       before = mlr_reflections$task_print_col_roles$before
-      iwalk(before[before %in% names(roles)], function(role, str) {
+      iwalk(before[before %chin% names(roles)], function(role, str) {
         catn(str_indent(sprintf("* %s:", str), roles[[role]]))
       })
 
@@ -246,7 +246,7 @@ Task = R6Class("Task",
 
       # print additional columns are specified in reflections
       after = mlr_reflections$task_print_col_roles$after
-      iwalk(after[after %in% names(roles)], function(role, str) {
+      iwalk(after[after %chin% names(roles)], function(role, str) {
         catn(str_indent(sprintf("* %s:", str), roles[[role]]))
       })
 
@@ -371,7 +371,7 @@ Task = R6Class("Task",
     levels = function(cols = NULL) {
       if (is.null(cols)) {
         cols = unlist(private$.col_roles[c("target", "feature")], use.names = FALSE)
-        cols = self$col_info[get("id") %in% cols & get("type") %in% c("factor", "ordered"), "id", with = FALSE][[1L]]
+        cols = self$col_info[get("id") %chin% cols & get("type") %chin% c("factor", "ordered"), "id", with = FALSE][[1L]]
       } else {
         assert_subset(cols, self$col_info$id)
       }
@@ -469,7 +469,7 @@ Task = R6Class("Task",
       type_check = TRUE
 
       if (is.data.frame(data)) {
-        pk_in_backend = pk %in% names(data)
+        pk_in_backend = pk %chin% names(data)
         type_check = FALSE # done by auto-converter
 
         keep_cols = intersect(names(data), self$col_info$id)
@@ -521,7 +521,7 @@ Task = R6Class("Task",
       }
 
       # merge factor levels
-      ii = tab[type %in% c("factor", "ordered"), which = TRUE]
+      ii = tab[type %chin% c("factor", "ordered"), which = TRUE]
       for (i in ii) {
         x = tab[["levels"]][[i]]
         y = tab[["levels_y"]][[i]]
@@ -730,7 +730,7 @@ Task = R6Class("Task",
     #' @return Modified `self`.
     droplevels = function(cols = NULL) {
       assert_has_backend(self)
-      tab = self$col_info[get("type") %in% c("factor", "ordered"), c("id", "levels", "fix_factor_levels"), with = FALSE]
+      tab = self$col_info[get("type") %chin% c("factor", "ordered"), c("id", "levels", "fix_factor_levels"), with = FALSE]
       if (!is.null(cols)) {
         tab = tab[list(cols), on = "id", nomatch = NULL]
       }
@@ -930,7 +930,7 @@ Task = R6Class("Task",
 
       assert_has_backend(self)
       assert_list(rhs, .var.name = "row_roles")
-      if ("test" %in% names(rhs) || "holdout" %in% names(rhs)) {
+      if ("test" %chin% names(rhs) || "holdout" %chin% names(rhs)) {
         stopf("Setting row roles 'test'/'holdout' is no longer possible.")
       }
       assert_names(names(rhs), "unique", permutation.of = mlr_reflections$task_row_roles, .var.name = "names of row_roles")
@@ -1337,7 +1337,7 @@ col_info = function(x, ...) {
 #' @export
 col_info.data.table = function(x, primary_key = character(), ...) { # nolint
   types = map_chr(x, function(x) class(x)[1L])
-  discrete = setdiff(names(types)[types %in% c("factor", "ordered")], primary_key)
+  discrete = setdiff(names(types)[types %chin% c("factor", "ordered")], primary_key)
   levels = insert_named(named_list(names(types)), lapply(x[, discrete, with = FALSE], distinct_values, drop = FALSE))
   data.table(id = names(types), type = unname(types), levels = levels, key = "id")
 }
@@ -1346,7 +1346,7 @@ col_info.data.table = function(x, primary_key = character(), ...) { # nolint
 #' @export
 col_info.DataBackend = function(x, ...) { # nolint
   types = map_chr(x$head(1L), function(x) class(x)[1L])
-  discrete = setdiff(names(types)[types %in% c("factor", "ordered")], x$primary_key)
+  discrete = setdiff(names(types)[types %chin% c("factor", "ordered")], x$primary_key)
   levels = insert_named(named_list(names(types)), x$distinct(rows = NULL, cols = discrete))
   data.table(id = names(types), type = unname(types), levels = levels, key = "id")
 }

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -181,7 +181,7 @@ assert_predictable = function(task, learner) {
       stopf("Learner '%s' has received tasks with different columns in train and predict.", learner$id)
     }
 
-    ids = train_task$col_info[get("id") %in% cols_train, "id"]$id
+    ids = train_task$col_info[get("id") %chin% cols_train, "id"]$id
     ci_predict = task$col_info[list(ids), c("id", "type", "levels"), on = "id"]
     ci_train = train_task$col_info[list(ids), c("id", "type", "levels"), on = "id"]
 
@@ -260,11 +260,11 @@ assert_measure = function(measure, task = NULL, learner = NULL, prediction = NUL
 #' @param prediction ([Prediction]).
 #' @rdname mlr_assertions
 assert_scorable = function(measure, task, learner, prediction = NULL, .var.name = vname(measure)) {
-  if ("requires_model" %in% measure$properties && is.null(learner$model)) {
+  if ("requires_model" %chin% measure$properties && is.null(learner$model)) {
     stopf("Measure '%s' requires the trained model", measure$id)
   }
 
-  if ("requires_model" %in% measure$properties && is_marshaled_model(learner$model)) {
+  if ("requires_model" %chin% measure$properties && is_marshaled_model(learner$model)) {
     stopf("Measure '%s' requires the trained model, but model is in marshaled form", measure$id)
   }
 

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -110,13 +110,13 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
 
   setDT(design)
   task = learner = resampling = NULL
-  if ("task" %in% clone) {
+  if ("task" %chin% clone) {
     design[, "task" := list(list(task[[1L]]$clone())), by = list(hashes(task))]
   }
-  if ("learner" %in% clone) {
+  if ("learner" %chin% clone) {
     design[, "learner" := list(list(learner[[1L]]$clone())), by = list(hashes(learner))]
   }
-  if ("resampling" %in% clone) {
+  if ("resampling" %chin% clone) {
     design[, "resampling" := list(list(resampling[[1L]]$clone())), by = list(hashes(resampling))]
   }
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -57,9 +57,9 @@
 #' print(bmr1$combine(bmr2))
 resample = function(task, learner, resampling, store_models = FALSE, store_backends = TRUE, encapsulate = NA_character_, allow_hotstart = FALSE, clone = c("task", "learner", "resampling"), unmarshal = TRUE) {
   assert_subset(clone, c("task", "learner", "resampling"))
-  task = assert_task(as_task(task, clone = "task" %in% clone))
-  learner = assert_learner(as_learner(learner, clone = "learner" %in% clone, discard_state = TRUE))
-  resampling = assert_resampling(as_resampling(resampling, clone = "resampling" %in% clone))
+  task = assert_task(as_task(task, clone = "task" %chin% clone))
+  learner = assert_learner(as_learner(learner, clone = "learner" %chin% clone, discard_state = TRUE))
+  resampling = assert_resampling(as_resampling(resampling, clone = "resampling" %chin% clone))
   assert_flag(store_models)
   assert_flag(store_backends)
   # this does not check the internal validation task as it might not be set yet

--- a/R/set_validate.R
+++ b/R/set_validate.R
@@ -26,7 +26,7 @@ set_validate = function(learner, validate, ...) {
 
 #' @export
 set_validate.Learner = function(learner, validate, ...) {
-  if (!"validation" %in% learner$properties) {
+  if (!"validation" %chin% learner$properties) {
     stopf("Learner '%s' does not support validation.", learner$id)
   }
   learner$validate = validate

--- a/R/worker.R
+++ b/R/worker.R
@@ -255,7 +255,7 @@ workhorse = function(iteration, task, learner, resampling, param_values = NULL, 
   if (!is.null(pb)) {
     pb(sprintf("%s|%s|i:%i", task$id, learner$id, iteration))
   }
-  if ("internal_valid" %in% learner$predict_sets && is.null(task$internal_valid_task) && is.null(get0("validate", learner))) {
+  if ("internal_valid" %chin% learner$predict_sets && is.null(task$internal_valid_task) && is.null(get0("validate", learner))) {
     stopf("Cannot set the predict_type field of learner '%s' to 'internal_valid' if there is no internal validation task configured", learner$id)
   }
 
@@ -351,7 +351,7 @@ prediction_tasks_and_sets = function(task, train_result, validate, sets, predict
     return(list(tasks = tasks[predict_sets], sets = sets[predict_sets]))
   }
 
-  if ("internal_valid" %in% predict_sets) {
+  if ("internal_valid" %chin% predict_sets) {
     if (is.numeric(validate) || identical(validate, "test")) {
       # in this scenario, the internal_valid_task was created during learner_train, which means that it used the
       # primary task. The selected ids are returned via the train result

--- a/tests/testthat/test_HotstartStack.R
+++ b/tests/testthat/test_HotstartStack.R
@@ -134,7 +134,7 @@ test_that("HotstartStack works with backward target learner and decreased hotsta
   learner_1$train(task)
 
   learner = lrn("classif.debug", iter = 1)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1))
 
   expect_equal(hot$start_cost(learner, task$hash), 0)
@@ -151,7 +151,7 @@ test_that("HotstartStack works with backward target learner when cost of hotstar
   learner_2$train(task)
 
   learner = lrn("classif.debug", iter = 3)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1, learner_2))
 
   expect_equal(hot$start_cost(learner, task$hash), c(0, 0))
@@ -166,7 +166,7 @@ test_that("HotstartStack works when hotstart values of hotstart learners are low
   learner_2$train(task)
 
   learner = lrn("classif.debug", iter = 2)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1, learner_2))
 
   expect_equal(hot$start_cost(learner, task$hash), c(0, NA_real_))
@@ -181,7 +181,7 @@ test_that("HotstartStack works when backward hotstart and target learner are equ
   learner_1$train(task)
 
   learner = lrn("classif.debug", iter = 1)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1))
 
   expect_equal(hot$start_cost(learner, task$hash), -1)
@@ -197,7 +197,7 @@ test_that("HotstartStack works with backward target learner when hotstart values
   learner_1$train(task)
 
   learner = lrn("classif.debug", iter = 2)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1))
 
   expect_equal(hot$start_cost(learner, task$hash), NA_real_)
@@ -218,7 +218,7 @@ test_that("HotstartStack works with backward target learner when hotstart learne
   learner_4$train(task)
 
   learner = lrn("classif.debug", iter = 2)
-  learner$properties[learner$properties %in% "hotstart_forward"] = "hotstart_backward"
+  learner$properties[learner$properties %chin% "hotstart_forward"] = "hotstart_backward"
   hot = HotstartStack$new(list(learner_1, learner_2, learner_3, learner_4))
 
   expect_equal(hot$start_cost(learner, task$hash), c(NA_real_, -1, 0, NA_real_))

--- a/tests/testthat/test_PredictionRegr.R
+++ b/tests/testthat/test_PredictionRegr.R
@@ -45,9 +45,9 @@ test_that("c drops se (#250)", {
 
   pred = do.call(c, rr$predictions())
   expect_null(pred$data$se)
-  expect_false("se" %in% pred$predict_types)
+  expect_false("se" %chin% pred$predict_types)
   expect_true(allMissing(pred$se))
-  expect_false("se" %in% names(as.data.table(pred)))
+  expect_false("se" %chin% names(as.data.table(pred)))
 })
 
 test_that("distr", {

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -237,11 +237,11 @@ test_that("rename works", {
 
 test_that("stratify works", {
   task = tsk("iris")
-  expect_false("strata" %in% task$properties)
+  expect_false("strata" %chin% task$properties)
   expect_null(task$strata)
 
   task$col_roles$stratum = task$target_names
-  expect_true("strata" %in% task$properties)
+  expect_true("strata" %chin% task$properties)
   tab = task$strata
   expect_data_table(tab, ncols = 2, nrows = 3)
   expect_list(tab$row_id, "integer")
@@ -252,8 +252,8 @@ test_that("groups/weights work", {
   task = TaskRegr$new("test", b, target = "y")
   task$set_row_roles(16:20, character())
 
-  expect_false("groups" %in% task$properties)
-  expect_false("weights" %in% task$properties)
+  expect_false("groups" %chin% task$properties)
+  expect_false("weights" %chin% task$properties)
   expect_null(task$groups)
   expect_null(task$weights)
 
@@ -434,7 +434,7 @@ test_that("col roles getters/setters", {
   })
 
   task$col_roles$feature = setdiff(task$col_roles$feature, "Sepal.Length")
-  expect_false("Sepal.Length" %in% task$feature_names)
+  expect_false("Sepal.Length" %chin% task$feature_names)
 })
 
 test_that("Task$row_names", {
@@ -471,7 +471,7 @@ test_that("Task$set_col_roles", {
 
   task$set_col_roles("mass", add_to = "feature")
   expect_equal(task$n_features, 8L)
-  expect_true("mass" %in% task$feature_names)
+  expect_true("mass" %chin% task$feature_names)
 
   task$set_col_roles("age", roles = "weight")
   expect_equal(task$n_features, 7L)
@@ -480,7 +480,7 @@ test_that("Task$set_col_roles", {
 
   task$set_col_roles("age", add_to = "feature", remove_from = "weight")
   expect_equal(task$n_features, 8L)
-  expect_true("age" %in% task$feature_names)
+  expect_true("age" %chin% task$feature_names)
   expect_null(task$weights)
 })
 
@@ -659,7 +659,7 @@ test_that("cbind supports non-standard primary key (#961)", {
   b = as_data_backend(tbl, primary_key = "myid")
   task = as_task_regr(b, target = "y")
   task$cbind(data.table(x1 = 10:1))
-  expect_true("x1" %in% task$feature_names)
+  expect_true("x1" %chin% task$feature_names)
 })
 
 test_that("$select changes hash", {

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -85,9 +85,9 @@ test_that("bmr$combine()", {
     expect_data_table(get_private(bmr_new)$.data$data$fact, nrows = 6L)
     expect_data_table(get_private(bmr_combined)$.data$data$fact, nrows = 24L)
 
-    expect_false("pima" %in% bmr$tasks$task_id)
-    expect_true("pima" %in% bmr_new$tasks$task_id)
-    expect_true("pima" %in% bmr_combined$tasks$task_id)
+    expect_false("pima" %chin% bmr$tasks$task_id)
+    expect_true("pima" %chin% bmr_new$tasks$task_id)
+    expect_true("pima" %chin% bmr_combined$tasks$task_id)
   }
 
   rr = resample(tsk("zoo"), lrn("classif.rpart"), rsmp("holdout"))
@@ -212,7 +212,7 @@ test_that("extract params", {
   aggr = bmr$aggregate(params = TRUE)
   expect_list(aggr$params[[1]], names = "unique", len = 0L)
 
-  expect_true(all(c("warnings", "errors") %in% names(bmr$score(conditions = TRUE))))
+  expect_true(all(c("warnings", "errors") %chin% names(bmr$score(conditions = TRUE))))
 })
 
 test_that("benchmark_grid", {
@@ -480,7 +480,7 @@ test_that("param_values in benchmark", {
     x
   }
   trained = bmr$learners$learner
-  ii = which(map_lgl(trained, function(x) "cp" %in% names(x$param_set$values))) # find learner with cp
+  ii = which(map_lgl(trained, function(x) "cp" %chin% names(x$param_set$values))) # find learner with cp
   expect_count(ii)
 
   expect_equal(sortnames(bmr$learners$learner[-ii][[1]]$param_set$values), list(minbucket = 2, minsplit = 12, xval = 0))

--- a/tests/testthat/test_convert_task.R
+++ b/tests/testthat/test_convert_task.R
@@ -109,7 +109,7 @@ test_that("convert_task reconstructs task", {
   tsk2 = convert_task(task2)
   expect_equal(task2$nrow, tsk2$nrow)
   expect_equal(task2$ncol, tsk2$ncol)
-  expect_true("twoclass" %in% tsk2$properties)
+  expect_true("twoclass" %chin% tsk2$properties)
 
   task3 = task2
   task3$row_roles$use = 1:150
@@ -117,7 +117,7 @@ test_that("convert_task reconstructs task", {
   tsk3$man = "mlr3::mlr_tasks_iris"
   expect_equal(task3$nrow, tsk3$nrow)
   expect_equal(task3$ncol, tsk3$ncol)
-  expect_true("multiclass" %in% tsk3$properties)
+  expect_true("multiclass" %chin% tsk3$properties)
   expect_equal(task, tsk3, ignore_attr = TRUE)
 })
 

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -94,7 +94,7 @@ test_that("empty train/predict sets", {
 })
 
 test_that("conditions are returned", {
-  expect_true(all(c("warnings", "errors") %in% names(rr$score(conditions = TRUE))))
+  expect_true(all(c("warnings", "errors") %chin% names(rr$score(conditions = TRUE))))
 })
 
 test_that("save/load roundtrip", {


### PR DESCRIPTION
Not sure if this is wanted, but adds minor performance improvements. See the mini benchmark from data.table: https://rdatatable.gitlab.io/data.table/reference/chmatch.html#ref-examples. For small vectors it might not make much sense.