### PR TITLE
fix(task): don't call $data() unnecessarily

### DIFF
--- a/R/Task.R
+++ b/R/Task.R
@@ -1288,7 +1288,7 @@ task_check_col_roles.Task = function(task, new_roles, ...) {
     stopf("Offset column(s) %s must be a numeric or integer column", paste0("'", new_roles[["offset"]], "'", collapse = ","))
   }
 
-  if (any(task$missings(cols = new_roles[["offset"]]) > 0)) {
+  if (length(new_roles[["offset"]]) && any(task$missings(cols = new_roles[["offset"]]) > 0)) {
     missings = task$missings(cols = new_roles[["offset"]])
     missings = names(missings[missings > 0])
     stopf("Offset column(s) %s contain missing values", paste0("'", missings, "'", collapse = ","))

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -731,3 +731,17 @@ test_that("warn when internal valid task has 0 obs", {
   expect_warning({task$internal_valid_task = 151}, "has 0 observations")
 })
 
+
+test_that("$data() is not called during task construction", {
+  tbl = data.table(x = 1:10, y = 1:10, ..row_id = 1:10)
+  DataBackendTest = R6Class("DataBackendTest",
+    inherit = DataBackendDataTable,
+    cloneable = FALSE,
+    public = list(
+      data = function(rows, cols, data_format) {
+        stop("Bug")
+      }
+    )
+  )$new(tbl, "..row_id")
+  expect_task(as_task_regr(tbl, target = "y"))
+})


### PR DESCRIPTION
For tasks in mlr3torch, `$data()` can cause downloads of large files, but it should be possible to construct tasks without downloading the data (e.g. for as.data.table(mlr_tasks)).