### PR TITLE
chore: bump R version to 3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ License: LGPL-3
 URL: https://mlr3.mlr-org.com, https://github.com/mlr-org/mlr3
 BugReports: https://github.com/mlr-org/mlr3/issues
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.3.0)
 Imports:
     R6 (>= 2.4.1),
     backports,


### PR DESCRIPTION
Changes the min R version to 3.3 to reflect the min version used by data.table.