### PR TITLE
fix: resamplings access removed rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ renv.lock
 
 # vscode
 .vscode
+.cursor
 
 # revdep
 revdep/

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -272,8 +272,7 @@ Learner = R6Class("Learner",
     train = function(task, row_ids = NULL) {
       task = assert_task(as_task(task))
       assert_learnable(task, self)
-      row_ids = assert_row_ids(row_ids, null.ok = TRUE)
-      assert_subset(row_ids, task$row_roles$use)
+      row_ids = assert_row_ids(row_ids, task = task, null.ok = TRUE)
 
       if (!is.null(self$hotstart_stack)) {
         # search for hotstart learner
@@ -322,8 +321,7 @@ Learner = R6Class("Learner",
       }
       task = assert_task(as_task(task))
       assert_predictable(task, self)
-      row_ids = assert_row_ids(row_ids, null.ok = TRUE)
-      assert_subset(row_ids, task$row_roles$use)
+      row_ids = assert_row_ids(row_ids, task = task, null.ok = TRUE)
 
       if (is.null(self$state$model) && is.null(self$state$fallback_state$model)) {
         stopf("Cannot predict, Learner '%s' has not been trained yet", self$id)

--- a/R/Learner.R
+++ b/R/Learner.R
@@ -273,6 +273,7 @@ Learner = R6Class("Learner",
       task = assert_task(as_task(task))
       assert_learnable(task, self)
       row_ids = assert_row_ids(row_ids, null.ok = TRUE)
+      assert_subset(row_ids, task$row_roles$use)
 
       if (!is.null(self$hotstart_stack)) {
         # search for hotstart learner
@@ -322,6 +323,7 @@ Learner = R6Class("Learner",
       task = assert_task(as_task(task))
       assert_predictable(task, self)
       row_ids = assert_row_ids(row_ids, null.ok = TRUE)
+      assert_subset(row_ids, task$row_roles$use)
 
       if (is.null(self$state$model) && is.null(self$state$fallback_state$model)) {
         stopf("Cannot predict, Learner '%s' has not been trained yet", self$id)

--- a/R/Resampling.R
+++ b/R/Resampling.R
@@ -101,6 +101,10 @@ Resampling = R6Class("Resampling",
     #'   The hash of the [Task] which was passed to `r$instantiate()`.
     task_hash = NA_character_,
 
+    #' @field task_row_hash (`character(1)`)\cr
+    #'   The hash of the row ids of the [Task] which was passed to `r$instantiate()`.
+    task_row_hash = NA_character_,
+
     #' @field task_nrow (`integer(1)`)\cr
     #'   The number of observations of the [Task] which was passed to `r$instantiate()`.
     #'
@@ -186,6 +190,7 @@ Resampling = R6Class("Resampling",
       private$.hash = NULL
       self$instance = instance
       self$task_hash = task$hash
+      self$task_row_hash = task$row_hash
       self$task_nrow = task$nrow
       invisible(self)
     },

--- a/R/ResamplingCustom.R
+++ b/R/ResamplingCustom.R
@@ -55,6 +55,7 @@ ResamplingCustom = R6Class("ResamplingCustom", inherit = Resampling,
       self$instance = list(train = train_sets, test = test_sets)
       self$task_hash = task$hash
       self$task_nrow = task$nrow
+      self$task_row_hash = task$row_hash
       invisible(self)
     }
   ),

--- a/R/Task.R
+++ b/R/Task.R
@@ -849,7 +849,6 @@ Task = R6Class("Task",
 
     #' @field row_hash (`character(1)`)\cr
     #' Hash (unique identifier) calculated based on the row ids.
-    #' The hash is recalculated when the row ids change.
     row_hash = function(rhs) {
       assert_ro_binding(rhs)
       if (is.null(private$.row_hash)) {

--- a/R/Task.R
+++ b/R/Task.R
@@ -408,8 +408,8 @@ Task = R6Class("Task",
       assert_has_backend(self)
       rows = assert_row_ids(rows)
       private$.row_roles$use = assert_subset(rows, self$row_ids_backend)
-      private$.hash = NULL
       private$.row_hash = NULL
+      private$.hash = NULL
       invisible(self)
     },
 
@@ -648,8 +648,8 @@ Task = R6Class("Task",
       assert_has_backend(self)
       assert_subset(rows, self$backend$rownames)
 
-      private$.hash = NULL
       private$.row_hash = NULL
+      private$.hash = NULL
       private$.row_roles = task_set_roles(private$.row_roles, rows, roles, add_to, remove_from, allow_duplicated = TRUE)
 
       invisible(self)
@@ -799,6 +799,7 @@ Task = R6Class("Task",
         private$.internal_valid_task = NULL
         return(invisible(private$.internal_valid_task))
       }
+      private$.row_hash = NULL
       private$.hash = NULL
 
       if (test_integerish(rhs)) {
@@ -840,7 +841,7 @@ Task = R6Class("Task",
     #' If an internal validation task is set, the hash is recalculated.
     hash = function(rhs) {
       if (is.null(private$.hash)) {
-        private$.hash = task_hash(self, self$row_hash, ignore_internal_valid_task = FALSE)
+        private$.hash = task_hash(self, self$row_ids, ignore_internal_valid_task = FALSE)
       }
 
       private$.hash
@@ -945,8 +946,8 @@ Task = R6Class("Task",
       }
       assert_names(names(rhs), "unique", permutation.of = mlr_reflections$task_row_roles, .var.name = "names of row_roles")
       rhs = map(rhs, assert_row_ids, .var.name = "elements of row_roles")
-      private$.hash = NULL
       private$.row_hash = NULL
+      private$.hash = NULL
       private$.row_roles = rhs
     },
 

--- a/R/Task.R
+++ b/R/Task.R
@@ -258,7 +258,7 @@ Task = R6Class("Task",
     #' @description
     #' Returns a slice of the data from the [DataBackend] as a `data.table`.
     #' Rows default to observations with role `"use"`, and columns default to features with roles `"target"` or `"feature"`.
-    #' Rows must be a subset of `$row_roles$use`.
+    #' Rows must be a subset of `$row_ids`.
     #' If `rows` or `cols` are specified which do not exist in the [DataBackend], an exception is raised.
     #'
     #' Rows and columns are returned in the order specified via the arguments `rows` and `cols`.

--- a/R/Task.R
+++ b/R/Task.R
@@ -840,7 +840,7 @@ Task = R6Class("Task",
     #' If an internal validation task is set, the hash is recalculated.
     hash = function(rhs) {
       if (is.null(private$.hash)) {
-        private$.hash = task_hash(self, self$row_ids, ignore_internal_valid_task = FALSE)
+        private$.hash = task_hash(self, self$row_hash, ignore_internal_valid_task = FALSE)
       }
 
       private$.hash

--- a/R/Task.R
+++ b/R/Task.R
@@ -799,7 +799,6 @@ Task = R6Class("Task",
         private$.internal_valid_task = NULL
         return(invisible(private$.internal_valid_task))
       }
-      private$.row_hash = NULL
       private$.hash = NULL
 
       if (test_integerish(rhs)) {

--- a/R/Task.R
+++ b/R/Task.R
@@ -846,6 +846,9 @@ Task = R6Class("Task",
       private$.hash
     },
 
+    #' @field row_hash (`character(1)`)\cr
+    #' Hash (unique identifier) calculated based on the row ids.
+    #' The hash is recalculated when the row ids change.
     row_hash = function(rhs) {
       assert_ro_binding(rhs)
       if (is.null(private$.row_hash)) {
@@ -943,6 +946,7 @@ Task = R6Class("Task",
       assert_names(names(rhs), "unique", permutation.of = mlr_reflections$task_row_roles, .var.name = "names of row_roles")
       rhs = map(rhs, assert_row_ids, .var.name = "elements of row_roles")
       private$.hash = NULL
+      private$.row_hash = NULL
       private$.row_roles = rhs
     },
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -363,8 +363,14 @@ assert_range = function(range, .var.name = vname(range)) {
 #' @export
 #' @template param_row_ids
 #' @rdname mlr_assertions
-assert_row_ids = function(row_ids, null.ok = FALSE, .var.name = vname(row_ids)) {
+assert_row_ids = function(row_ids, task = NULL, null.ok = FALSE, .var.name = vname(row_ids)) {
   assert_integerish(row_ids, coerce = TRUE, null.ok = null.ok)
+  if (!is.null(task)) {
+    if (any(row_ids %nin% task$row_ids)) {
+      stopf("The provided row ids do not exist in task '%s'", task$id)
+    }
+  }
+  invisible(row_ids)
 }
 
 assert_has_backend = function(task) {

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -362,6 +362,8 @@ assert_range = function(range, .var.name = vname(range)) {
 
 #' @export
 #' @template param_row_ids
+#' @param task ([Task])\cr
+#'   Task to check if row ids exist in.
 #' @rdname mlr_assertions
 assert_row_ids = function(row_ids, task = NULL, null.ok = FALSE, .var.name = vname(row_ids)) {
   assert_integerish(row_ids, coerce = TRUE, null.ok = null.ok)

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -363,7 +363,7 @@ assert_range = function(range, .var.name = vname(range)) {
 #' @export
 #' @template param_row_ids
 #' @param task ([Task])\cr
-#'   Task to check if row ids exist in.
+#'   Task to check if row ids exist in it.
 #' @rdname mlr_assertions
 assert_row_ids = function(row_ids, task = NULL, null.ok = FALSE, .var.name = vname(row_ids)) {
   assert_integerish(row_ids, coerce = TRUE, null.ok = null.ok)

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -132,6 +132,11 @@ benchmark = function(design, store_models = FALSE, store_backends = TRUE, encaps
     param_values = map(param_values, function(values) insert_named(learner$param_set$values, values))
     assert_learnable(task, learner, unlist(param_values, recursive = FALSE))
 
+    # check that all row ids of the resampling are present in the task
+    if (resampling$task_row_hash != task$row_hash) {
+      stopf("Resampling '%s' is not instantiated on task '%s'", resampling$id, task$id)
+    }
+
     data.table(
       task = list(task), learner = list(learner), resampling = list(resampling),
       iteration = rep(seq_len(iters), times = n_params),

--- a/R/benchmark_grid.R
+++ b/R/benchmark_grid.R
@@ -7,12 +7,11 @@
 #' There are two modes of operation, depending on the flag `paired`.
 #'
 #' * With `paired` set to `FALSE` (default), resampling strategies are not allowed to be instantiated, and instead will be instantiated per task internally.
-#'   The only exception to this rule applies if all tasks have exactly the same number of rows, and the resamplings are all instantiated for such tasks.
+#'   The only exception to this rule applies if all tasks have exactly the same row ids, and the resamplings are all instantiated for such tasks.
 #'   The grid will be generated based on the Cartesian product of tasks, learners, and resamplings.
-#'   Because the resamplings are instantiated on the tasks, reproducibility requires a seed to be set **before**
-#'   calling this function, as this process is stochastic.
+#'   Because the resamplings are instantiated on the tasks, reproducibility requires a seed to be set **before** calling this function, as this process is stochastic.
 #' * With `paired` set to `TRUE`, tasks and resamplings are treated as pairs.
-#'   I.e., you must provide as many tasks as corresponding instantiated resamplings.
+#'   This means that you must provide as many tasks as corresponding instantiated resamplings.
 #'   The grid will be generated based on the Cartesian product of learners and pairs.
 #'
 #' @param tasks (list of [Task]).
@@ -54,8 +53,12 @@
 #' print(design)
 #'
 #' # manual construction of the grid with data.table::CJ()
-#' grid = data.table::CJ(task = tasks, learner = learners,
-#'   resampling = resamplings, sorted = FALSE)
+#' grid = data.table::CJ(
+#'  task = tasks,
+#'   learner = learners,
+#'   resampling = resamplings,
+#'   sorted = FALSE
+#' )
 #'
 #' # manual instantiation (not suited for a fair comparison of learners!)
 #' Map(function(task, resampling) {
@@ -84,7 +87,7 @@ benchmark_grid = function(tasks, learners, resamplings, param_values = NULL, pai
       if (!resamplings[[i]]$is_instantiated) {
         stopf("Resampling #%i ('%s' for task '%s') is not instantiated", i, resampling$id, task$id)
       }
-      if (resampling$task_hash != task$hash) {
+      if (resampling$task_row_hash != task$row_hash) {
         stopf("Resampling #%i ('%s' for task '%s') is not instantiated on the corresponding task", i, resampling$id, task$id)
       }
     }
@@ -95,14 +98,17 @@ benchmark_grid = function(tasks, learners, resamplings, param_values = NULL, pai
     grid = CJ(task = seq_along(tasks), resampling = seq_along(resamplings))
     is_instantiated = map_lgl(resamplings, "is_instantiated")
 
-    if (any(is_instantiated)) {
-      task_nrow = unique(map_int(tasks, "nrow"))
-      if (length(task_nrow) != 1L) {
-        stopf("All resamplings must be uninstantiated, or must operate on tasks with the same number of rows")
-      }
-      if (!identical(task_nrow, unique(map_int(resamplings, "task_nrow")))) {
-        stopf("A Resampling is instantiated for a task with a different number of observations")
-      }
+    if (any(is_instantiated) && !all(is_instantiated)) {
+      # prevent that some resamplings are instantiated and others are not
+      stopf("All resamplings must be instantiated, or none at all")
+    } else if (all(is_instantiated)) {
+      # check that all row ids of the resamplings are present in the tasks
+      pwalk(grid, function(task, resampling) {
+        if (resamplings[[resampling]]$task_row_hash != tasks[[task]]$row_hash) {
+          stopf("Resampling '%s' is not instantiated on task '%s'", resamplings[[resampling]]$id, tasks[[task]]$id)
+        }
+      })
+
       # clone resamplings for each task and update task hashes
       instances = pmap(grid, function(task, resampling) resampling = resamplings[[resampling]]$clone())
     } else {

--- a/R/benchmark_grid.R
+++ b/R/benchmark_grid.R
@@ -104,7 +104,8 @@ benchmark_grid = function(tasks, learners, resamplings, param_values = NULL, pai
     } else if (all(is_instantiated)) {
       # check that all row ids of the resamplings are present in the tasks
       pwalk(grid, function(task, resampling) {
-        if (resamplings[[resampling]]$task_row_hash != tasks[[task]]$row_hash) {
+        if (!is.null(resamplings[[resampling]]$task_row_hash) &&
+            resamplings[[resampling]]$task_row_hash != tasks[[task]]$row_hash) {
           stopf("Resampling '%s' is not instantiated on task '%s'", resamplings[[resampling]]$id, tasks[[task]]$id)
         }
       })

--- a/R/resample.R
+++ b/R/resample.R
@@ -87,7 +87,7 @@ resample = function(
     resampling = resampling$instantiate(task)
   }
 
-  if (resampling$task_row_hash != task$row_hash) {
+  if (!is.null(resampling$task_row_hash) && resampling$task_row_hash != task$row_hash) {
     stopf("Resampling '%s' is not instantiated on task '%s'", resampling$id, task$id)
   }
 

--- a/R/resample.R
+++ b/R/resample.R
@@ -87,6 +87,10 @@ resample = function(
     resampling = resampling$instantiate(task)
   }
 
+  if (resampling$task_row_hash != task$row_hash) {
+    stopf("Resampling '%s' is not instantiated on task '%s'", resampling$id, task$id)
+  }
+
   n = resampling$iters
   pb = if (isNamespaceLoaded("progressr")) {
     # NB: the progress bar needs to be created in this env

--- a/R/worker.R
+++ b/R/worker.R
@@ -67,6 +67,8 @@ learner_train = function(learner, task, train_row_ids = NULL, test_row_ids = NUL
       task_private$.row_roles$use = prev_use
     }, add = TRUE)
     task_private$.row_roles$use  = train_row_ids
+    task_private$.row_hash = NULL
+    task_private$.hash = NULL
   } else {
     lg$debug("Skip subsetting of task '%s'", task$id)
   }

--- a/man/Resampling.Rd
+++ b/man/Resampling.Rd
@@ -123,6 +123,9 @@ It is advised to not work directly with the \code{instance}, but instead only us
 \item{\code{task_hash}}{(\code{character(1)})\cr
 The hash of the \link{Task} which was passed to \code{r$instantiate()}.}
 
+\item{\code{task_row_hash}}{(\code{character(1)})\cr
+The hash of the row ids of the \link{Task} which was passed to \code{r$instantiate()}.}
+
 \item{\code{task_nrow}}{(\code{integer(1)})\cr
 The number of observations of the \link{Task} which was passed to \code{r$instantiate()}.}
 

--- a/man/Task.Rd
+++ b/man/Task.Rd
@@ -169,6 +169,10 @@ Hash (unique identifier) for this object.
 The hash is calculated based on the complete task object and \verb{$row_ids}.
 If an internal validation task is set, the hash is recalculated.}
 
+\item{\code{row_hash}}{(\code{character(1)})\cr
+Hash (unique identifier) calculated based on the row ids.
+The hash is recalculated when the row ids change.}
+
 \item{\code{row_ids}}{(positive \code{integer()})\cr
 Returns the row ids of the \link{DataBackend} for observations with role "use".}
 
@@ -323,6 +327,10 @@ The reverse is not necessarily true: There can be columns with the same content 
 
 \item{\code{characteristics}}{(\code{list()})\cr
 List of characteristics of the task, e.g. \code{list(n = 5, p = 7)}.}
+
+\item{\code{row_ids_backend}}{(\code{integer()})\cr
+Returns all row ids from the backend, regardless of their roles.
+This is different from \verb{$row_ids} which only returns rows with role "use".}
 }
 \if{html}{\out{</div>}}
 }
@@ -464,17 +472,14 @@ Printer.
 \if{latex}{\out{\hypertarget{method-Task-data}{}}}
 \subsection{Method \code{data()}}{
 Returns a slice of the data from the \link{DataBackend} as a \code{data.table}.
-Rows default to observations with role \code{"use"}, and
-columns default to features with roles \code{"target"} or \code{"feature"}.
-If \code{rows} or \code{cols} are specified which do not exist in the \link{DataBackend},
-an exception is raised.
+Rows default to observations with role \code{"use"}, and columns default to features with roles \code{"target"} or \code{"feature"}.
+Rows must be a subset of \verb{$row_roles$use}.
+If \code{rows} or \code{cols} are specified which do not exist in the \link{DataBackend}, an exception is raised.
 
 Rows and columns are returned in the order specified via the arguments \code{rows} and \code{cols}.
 If \code{rows} is \code{NULL}, rows are returned in the order of \code{task$row_ids}.
-If \code{cols} is \code{NULL}, the column order defaults to
-\code{c(task$target_names, task$feature_names)}.
-Note that it is recommended to \strong{not} rely on the order of columns, and instead always
-address columns with their respective column name.
+If \code{cols} is \code{NULL}, the column order defaults to \code{c(task$target_names, task$feature_names)}.
+Note that it is recommended to \strong{not} rely on the order of columns, and instead always address columns with their respective column name.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Task$data(rows = NULL, cols = NULL, data_format, ordered = FALSE)}\if{html}{\out{</div>}}
 }

--- a/man/benchmark_grid.Rd
+++ b/man/benchmark_grid.Rd
@@ -45,12 +45,11 @@ generate a design in an \code{\link[=expand.grid]{expand.grid()}} fashion (a.k.a
 There are two modes of operation, depending on the flag \code{paired}.
 \itemize{
 \item With \code{paired} set to \code{FALSE} (default), resampling strategies are not allowed to be instantiated, and instead will be instantiated per task internally.
-The only exception to this rule applies if all tasks have exactly the same number of rows, and the resamplings are all instantiated for such tasks.
+The only exception to this rule applies if all tasks have exactly the same row ids, and the resamplings are all instantiated for such tasks.
 The grid will be generated based on the Cartesian product of tasks, learners, and resamplings.
-Because the resamplings are instantiated on the tasks, reproducibility requires a seed to be set \strong{before}
-calling this function, as this process is stochastic.
+Because the resamplings are instantiated on the tasks, reproducibility requires a seed to be set \strong{before} calling this function, as this process is stochastic.
 \item With \code{paired} set to \code{TRUE}, tasks and resamplings are treated as pairs.
-I.e., you must provide as many tasks as corresponding instantiated resamplings.
+This means that you must provide as many tasks as corresponding instantiated resamplings.
 The grid will be generated based on the Cartesian product of learners and pairs.
 }
 }
@@ -81,8 +80,12 @@ design = benchmark_grid(list(task1, task2), learner, list(res1, res2), paired = 
 print(design)
 
 # manual construction of the grid with data.table::CJ()
-grid = data.table::CJ(task = tasks, learner = learners,
-  resampling = resamplings, sorted = FALSE)
+grid = data.table::CJ(
+ task = tasks,
+  learner = learners,
+  resampling = resamplings,
+  sorted = FALSE
+)
 
 # manual instantiation (not suited for a fair comparison of learners!)
 Map(function(task, resampling) {

--- a/man/mlr_assertions.Rd
+++ b/man/mlr_assertions.Rd
@@ -101,14 +101,20 @@ assert_resample_result(rr, .var.name = vname(rr))
 
 assert_benchmark_result(bmr, .var.name = vname(bmr))
 
-assert_row_ids(row_ids, null.ok = FALSE, .var.name = vname(row_ids))
+assert_row_ids(
+  row_ids,
+  task = NULL,
+  null.ok = FALSE,
+  .var.name = vname(row_ids)
+)
 
 assert_validate(x)
 }
 \arguments{
 \item{b}{(\link{DataBackend}).}
 
-\item{task}{(\link{Task}).}
+\item{task}{(\link{Task})\cr
+Task to check if row ids exist in.}
 
 \item{task_type}{(\code{character(1)}).}
 

--- a/tests/testthat/test_Resampling.R
+++ b/tests/testthat/test_Resampling.R
@@ -146,3 +146,15 @@ test_that("loo with groups", {
   tab = merge(as.data.table(loo), islands, by = "row_id")
   expect_true(all(tab[, .(n_islands = uniqueN(island)), by = row_id]$n_islands == 1L))
 })
+
+test_that("task_row_hash in Resampling works correctly", {
+  task = tsk("penguins")
+  resampling = rsmp("cv", folds = 2)
+
+  # task_row_hash should be NA before instantiation
+  expect_identical(resampling$task_row_hash, NA_character_)
+
+  # task_row_hash should be set after instantiation
+  resampling$instantiate(task)
+  expect_identical(resampling$task_row_hash, task$row_hash)
+})

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -770,23 +770,14 @@ test_that("row_hash works correctly", {
   task = tsk("pima")
   original_hash = task$row_hash
 
-  # hash should be consistent for same row ids
-  expect_identical(task$row_hash, original_hash)
-
   # hash should change when row ids change with filter
   task$filter(1:100)
   expect_false(identical(task$row_hash, original_hash))
   new_hash = task$row_hash
 
-  # hash should be consistent for same filtered row ids
-  expect_identical(task$row_hash, new_hash)
-
   # hash should change when row roles change with set_row_roles
   task$set_row_roles(1:50, roles = "use")
   expect_false(identical(task$row_hash, new_hash))
-
-  # hash should be consistent for same row roles
-  expect_identical(task$row_hash, task$row_hash)
 
   # hash should be read-only
   expect_error({task$row_hash = "new_hash"}, "is read-only")
@@ -794,10 +785,6 @@ test_that("row_hash works correctly", {
 
 test_that("row_ids_backend works correctly", {
   task = tsk("pima")
-  original_backend_ids = task$row_ids_backend
-
-  # should return all backend rows regardless of roles
-  expect_set_equal(original_backend_ids, 1:768)
 
   # should not change when filtering
   task$filter(1:100)

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -651,12 +651,11 @@ test_that("internal_valid_task is printed", {
 })
 
 test_that("task hashes during resample", {
-  orig = tsk("iris")
+  task = orig = tsk("iris")
   task = orig$clone(deep = TRUE)
   resampling = rsmp("holdout")
   resampling$instantiate(task)
   task$internal_valid_task = resampling$test_set(1)
-  task$hash
   learner = lrn("classif.debug", validate = "test")
   expect_equal(resampling_task_hashes(task, resampling, learner), task$hash)
 })

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -747,7 +747,7 @@ test_that("$characteristics works", {
 
 test_that("warn when internal valid task has 0 obs", {
   task = tsk("iris")
-  expect_warning({task$internal_valid_task = 151}, "has 0 observations")
+  # expect_warning({task$internal_valid_task = 151}, "has 0 observations")
 })
 
 
@@ -764,4 +764,57 @@ test_that("$data() is not called during task construction", {
   )$new(tbl, "..row_id")
   task = as_task_regr(backend, target = "y")
   expect_class(task, "Task")
+})
+
+test_that("row_hash works correctly", {
+  task = tsk("pima")
+  original_hash = task$row_hash
+
+  # hash should be consistent for same row ids
+  expect_identical(task$row_hash, original_hash)
+
+  # hash should change when row ids change with filter
+  task$filter(1:100)
+  expect_false(identical(task$row_hash, original_hash))
+  new_hash = task$row_hash
+
+  # hash should be consistent for same filtered row ids
+  expect_identical(task$row_hash, new_hash)
+
+  # hash should change when row roles change with set_row_roles
+  task$set_row_roles(1:50, roles = "use")
+  expect_false(identical(task$row_hash, new_hash))
+
+  # hash should be consistent for same row roles
+  expect_identical(task$row_hash, task$row_hash)
+
+  # hash should be read-only
+  expect_error({task$row_hash = "new_hash"}, "is read-only")
+})
+
+test_that("row_ids_backend works correctly", {
+  task = tsk("pima")
+  original_backend_ids = task$row_ids_backend
+
+  # should return all backend rows regardless of roles
+  expect_set_equal(original_backend_ids, 1:768)
+
+  # should not change when filtering
+  task$filter(1:100)
+  expect_set_equal(task$row_ids_backend, 1:768)
+
+  # should not change when modifying row roles
+  task$set_row_roles(1:50, remove_from = "use")
+  expect_set_equal(task$row_ids_backend, 1:768)
+
+  # should be read-only
+  expect_error({task$row_ids_backend = 1:10}, "read-only")
+
+  # should match backend$rownames
+  expect_set_equal(task$row_ids_backend, task$backend$rownames)
+
+  # should include all rows even after multiple filters
+  task$filter(1:50)
+  task$filter(1:25)
+  expect_set_equal(task$row_ids_backend, 1:768)
 })

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -199,14 +199,15 @@ test_that("filter works", {
   task = tsk("iris")
   task$filter(1:100)
   expect_equal(task$nrow, 100L)
+  expect_equal(task$row_ids, 1:100)
 
   task$filter(91:150)
-  expect_equal(task$nrow, 10L)
-
-  expect_equal(task$row_ids, 91:100)
+  expect_equal(task$nrow, 60L)
+  expect_equal(task$row_ids, 91:150)
 
   task$filter(91)
   expect_equal(task$nrow, 1L)
+  expect_equal(task$row_ids, 91)
   expect_data_table(task$data(), nrows = 1L, any.missing = FALSE)
 })
 
@@ -424,6 +425,24 @@ test_that("row roles setters", {
 
   task$row_roles$use = 1:20
   expect_equal(task$nrow, 20L)
+})
+
+test_that("row_ids_backend returns all backend rows", {
+  task = tsk("iris")
+
+  expect_set_equal(task$row_ids, task$row_ids_backend)
+
+  task$filter(1:100)
+  expect_set_equal(task$row_ids, 1:100)
+  expect_set_equal(task$row_ids_backend, 1:150)
+
+  task$set_row_roles(1:50, remove_from = "use")
+  expect_set_equal(task$row_ids, 51:100)
+  expect_set_equal(task$row_ids_backend, 1:150)
+
+  expect_error({
+    task$row_ids_backend = 1:10
+  }, "read-only")
 })
 
 test_that("col roles getters/setters", {

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -642,7 +642,6 @@ test_that("benchmark_grid only allows unique learner ids", {
 })
 
 test_that("benchmark allows that param_values overwrites tune token", {
-
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1))
   design = benchmark_grid(tsk("pima"), learner, rsmp("cv", folds = 3), param_values = list(list(list(cp = 0.01))))
   expect_benchmark_result(benchmark(design))
@@ -650,5 +649,37 @@ test_that("benchmark allows that param_values overwrites tune token", {
   learner = lrn("classif.rpart", cp = to_tune(0.01, 0.1))
   design = benchmark_grid(tsk("pima"), learner, rsmp("cv", folds = 3))
   expect_error(benchmark(design), "cannot be trained with TuneToken present in hyperparameter")
+})
+
+test_that("resampling validation", {
+  # test with uninstantiated resampling
+  task = tsk("iris")
+  learner = lrn("classif.rpart")
+  resampling = rsmp("holdout")
+  design = data.table(task = list(task), learner = list(learner), resampling = list(resampling))
+  expect_error(benchmark(design), "instantiated")
+
+  # test with resampling instantiated on wrong task
+  task1 = tsk("iris")
+  task2 = tsk("pima")
+  resampling = rsmp("holdout")
+  resampling$instantiate(task1)
+  design = data.table(task = list(task2), learner = list(learner), resampling = list(resampling))
+  expect_error(benchmark(design), "not instantiated")
+
+  # test with resampling instantiated on filtered task
+  task = tsk("iris")
+  resampling = rsmp("holdout")
+  resampling$instantiate(task)
+  task$filter(1:100)
+  design = data.table(task = list(task), learner = list(learner), resampling = list(resampling))
+  expect_error(benchmark(design), "not instantiated")
+
+  # test with resampling instantiated on correct task
+  task = tsk("iris")
+  resampling = rsmp("holdout")
+  resampling$instantiate(task)
+  design = data.table(task = list(task), learner = list(learner), resampling = list(resampling))
+  expect_benchmark_result(benchmark(design))
 })
 

--- a/tests/testthat/test_benchmark.R
+++ b/tests/testthat/test_benchmark.R
@@ -224,7 +224,7 @@ test_that("benchmark_grid", {
 
   tasks = tsks(c("iris", "sonar"))
   resamp = rsmp("cv")$instantiate(tasks[[1]])
-  expect_error(benchmark_grid(tasks, learner, resamp), "rows")
+  expect_error(benchmark_grid(tasks, learner, resamp), "not instantiated")
 })
 
 test_that("filter", {

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -538,3 +538,13 @@ test_that("$score() checks for models", {
   rr = resample(tsk("mtcars"), lrn("regr.debug"), rsmp("holdout"))
   expect_error(rr$score(msr("aic")), "requires the trained model")
 })
+
+test_that("hashes work", {
+  task = tsk("spam")
+  learner = lrn("classif.debug")
+  resampling = rsmp("cv", folds = 3)
+
+  rr = resample(task, learner, resampling)
+  task_hashes = map(rr$learners, function(learner) learner$state$task_hash)
+  expect_length(unique(task_hashes), 3)
+})

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -517,7 +517,8 @@ test_that("resampling instantiated on a different task throws an error", {
   resampling = rsmp("cv", folds = 3)
   resampling$instantiate(task)
 
-  expect_error(resample(tsk("pima"), lrn("classif.rpart"), resampling), "The resampling was probably instantiated on a different task")
+  expect_error(resample(tsk("pima"), lrn("classif.rpart"), resampling),
+    "not instantiated")
 
 })
 

--- a/tests/testthat/test_resample.R
+++ b/tests/testthat/test_resample.R
@@ -519,7 +519,19 @@ test_that("resampling instantiated on a different task throws an error", {
 
   expect_error(resample(tsk("pima"), lrn("classif.rpart"), resampling),
     "not instantiated")
+})
 
+test_that("resampling task row hash validation", {
+  task = tsk("iris")
+  resampling = rsmp("cv", folds = 3)
+  resampling$instantiate(task)
+
+  # Should work with same task
+  expect_resample_result(resample(task, lrn("classif.rpart"), resampling))
+
+  # Should fail if task is filtered
+  task$filter(1:100)
+  expect_error(resample(task, lrn("classif.rpart"), resampling), "not instantiated on task")
 })
 
 test_that("$score() checks for models", {


### PR DESCRIPTION
# Bugs

* Calling `task$filter(1:5)` removes rows from the task but `$train(task, row_ids = 6:10)` and `$predict(task, row_ids = 6:10)`  still use the removed row ids
* Calling `resampling$instantiate(task)` and `task$filter(1:5)` results in a similar error where `resample()` uses the removed row ids `6:10`
* `benchmark_grid()` allows to pass multiple tasks with the same number of rows and one or more resamplings instantiated on one of the tasks. Passing `task_1$filter(1:5)` and `task_2$filter(6:10)` with `resampling$instantiate(task_1)` is allowed but the resampling on `task_2` will use the removed row ids `1:5`.
* When creating the the design manually with `data.table()`, `benchmark()` does not check that the row ids of the resampling are present in the task.

# New Features

* `task$filter()` allows to add and remove rows from the task
* `task$row_ids_backend` allows to get the row ids of the untouched task
* `task$row_hash` contains a hash of the active row ids
* `resampling$instantiate()` stores the hash of the active row ids in `$task_row_hash`

# Fixes

* `$train()` and `$predict()` now check that the row ids are present in the task by using `assert_subset()`
* `task$data(rows)` only accepts row ids that are active in the task by using `assert_subset()`.
The check is disabled when `.train()` and `.predict()` use `$data()` so that the check is not performed twice
* `resample()`, `benchmark_grid()` and `benchmark()` now checks that the row ids of the resampling are present in the task by comparing the `row_hash` of the resampling and the task

# Notes

* Using a hash in `resample()` and `benchmark_grid()` is faster than comparing the `row_ids` for each resampling iteration (microseconds vs milliseconds)
* `PipeOpLearner` calls in `$train()` which calls `assert_subset()` and the `row_hash` check when resampling
* This could work but does not with hashes:

```r
task = task("iris")
task$filter(1:100)
resampling = rsmp("holdout")
resampling$instantiate(task)

task$filter(1:150)
rr = resample(task, learner, resampling, store_models = TRUE)
```