### PR TITLE
perf: use new faster `mlr3misc::compact()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Imports:
     lgr (>= 0.3.4),
     mlbench,
     mlr3measures (>= 1.0.0),
-    mlr3misc (>= 0.15.0),
+    mlr3misc (>= 0.17.0),
     parallelly,
     palmerpenguins,
     paradox (>= 1.0.1),

--- a/R/BenchmarkResult.R
+++ b/R/BenchmarkResult.R
@@ -586,8 +586,8 @@ BenchmarkResult = R6Class("BenchmarkResult",
     .data = NULL,
 
     .get_uhashes = function(i, uhashes, learner_ids, task_ids, resampling_ids) {
-      args = discard(list(learner_ids = learner_ids, task_ids = task_ids,
-        resampling_ids = resampling_ids), is.null)
+      args = compact(list(learner_ids = learner_ids, task_ids = task_ids,
+        resampling_ids = resampling_ids))
 
       if (sum(!is.null(i), !is.null(uhashes), length(args) > 0L) > 1) {
         stopf("At most one of `i`, `uhash`, or IDs can be provided.")

--- a/R/CallbackResample.R
+++ b/R/CallbackResample.R
@@ -129,7 +129,7 @@ callback_resample = function(
   on_resample_before_predict = NULL,
   on_resample_end = NULL
   ) {
-  stages = discard(set_names(list(
+  stages = compact(set_names(list(
     on_resample_begin,
     on_resample_before_train,
     on_resample_before_predict,
@@ -139,7 +139,7 @@ callback_resample = function(
       "on_resample_before_train",
       "on_resample_before_predict",
       "on_resample_end"
-    )), is.null)
+    )))
 
   stages = map(stages, function(stage) crate(assert_function(stage, args = c("callback", "context"))))
   callback = CallbackResample$new(id, label, man)

--- a/R/PredictionData.R
+++ b/R/PredictionData.R
@@ -21,7 +21,7 @@
 NULL
 
 new_prediction_data = function(li, task_type) {
-  li = discard(li, is.null)
+  li = compact(li)
   class(li) = c(fget(mlr_reflections$task_types, task_type, "prediction_data", "type"), "PredictionData")
   li
 }

--- a/R/as_prediction.R
+++ b/R/as_prediction.R
@@ -48,7 +48,7 @@ as_predictions.list = function(x, predict_sets = "test", ...) { # nolint
   ii = lengths(x) > 0L
   result[ii] = map(x[ii], function(li) {
     assert_list(li, "PredictionData")
-    li = discard(li[predict_sets], is.null)
+    li = compact(li[predict_sets])
     if (length(li) == 0L) {
       return(list())
     }

--- a/R/worker.R
+++ b/R/worker.R
@@ -378,7 +378,7 @@ workhorse = function(
   if (!length(predict_sets)) {
     learner$state$predict_time = 0L
   }
-  ctx$pdatas = discard(pdatas, is.null)
+  ctx$pdatas = compact(pdatas)
 
   # set the model slot after prediction so it can be sent back to the main process
   process_model_after_predict(


### PR DESCRIPTION
reference to minor benchmark: https://github.com/mlr-org/mlr3misc/pull/129