### PR TITLE
add ResamplingGroupOrStrata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -208,3 +208,4 @@ Collate:
     'task_converters.R'
     'worker.R'
     'zzz.R'
+Remotes: tdhock/mlr3@get_instance

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -208,4 +208,3 @@ Collate:
     'task_converters.R'
     'worker.R'
     'zzz.R'
-Remotes: tdhock/mlr3@get_instance

--- a/R/Resampling.R
+++ b/R/Resampling.R
@@ -173,25 +173,8 @@ Resampling = R6Class("Resampling",
     #' the object in its previous state.
     instantiate = function(task) {
       task = assert_task(as_task(task))
-      strata = task$strata
-      groups = task$groups
-
-      if (is.null(strata)) {
-        if (is.null(groups)) {
-          instance = private$.sample(task$row_ids, task = task)
-        } else {
-          private$.groups = groups
-          instance = private$.sample(unique(groups$group), task = task)
-        }
-      } else {
-        if (!is.null(groups)) {
-          stopf("Cannot combine stratification with grouping")
-        }
-        instance = private$.combine(lapply(strata$row_id, private$.sample, task = task))
-      }
-
       private$.hash = NULL
-      self$instance = instance
+      self$instance = self$get_instance(task)
       self$task_hash = task$hash
       self$task_row_hash = task$row_hash
       self$task_nrow = task$nrow
@@ -277,6 +260,28 @@ Resampling = R6Class("Resampling",
   )
 )
 
+ResamplingGroupOrStrata = R6Class("ResamplingGroupOrStrata",
+  inherit = Resampling,
+  public = list(
+    get_instance = function(task) {
+      strata = task$strata
+      groups = task$groups
+      if (is.null(strata)) {
+        if (is.null(groups)) {
+          private$.sample(task$row_ids, task = task)
+        } else {
+          private$.groups = groups
+          private$.sample(unique(groups$group), task = task)
+        }
+      } else {
+        if (!is.null(groups)) {
+          stopf("Cannot combine stratification with grouping")
+        }
+        private$.combine(lapply(strata$row_id, private$.sample, task = task))
+      }
+    }
+  )
+)
 
 #' @export
 as.data.table.Resampling = function(x, ...) { # nolint

--- a/R/ResamplingBootstrap.R
+++ b/R/ResamplingBootstrap.R
@@ -40,7 +40,7 @@
 #'
 #' # Internal storage:
 #' bootstrap$instance$M # Matrix of counts
-ResamplingBootstrap = R6Class("ResamplingBootstrap", inherit = Resampling,
+ResamplingBootstrap = R6Class("ResamplingBootstrap", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingCV.R
+++ b/R/ResamplingCV.R
@@ -36,7 +36,7 @@
 #'
 #' # Internal storage:
 #' cv$instance # table
-ResamplingCV = R6Class("ResamplingCV", inherit = Resampling,
+ResamplingCV = R6Class("ResamplingCV", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingCustom.R
+++ b/R/ResamplingCustom.R
@@ -24,7 +24,7 @@
 #'
 #' custom$train_set(1)
 #' custom$test_set(1)
-ResamplingCustom = R6Class("ResamplingCustom", inherit = Resampling,
+ResamplingCustom = R6Class("ResamplingCustom", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingCustomCV.R
+++ b/R/ResamplingCustomCV.R
@@ -35,7 +35,7 @@
 #'
 #' # Disjunct sets:
 #' intersect(custom_cv$train_set(1), custom_cv$test_set(1))
-ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = Resampling,
+ResamplingCustomCV = R6Class("ResamplingCustomCV", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingHoldout.R
+++ b/R/ResamplingHoldout.R
@@ -37,7 +37,7 @@
 #'
 #' # Internal storage:
 #' holdout$instance # simple list
-ResamplingHoldout = R6Class("ResamplingHoldout", inherit = Resampling,
+ResamplingHoldout = R6Class("ResamplingHoldout", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingInsample.R
+++ b/R/ResamplingInsample.R
@@ -25,7 +25,7 @@
 #'
 #' # Internal storage:
 #' insample$instance # just row ids
-ResamplingInsample = R6Class("ResamplingInsample", inherit = Resampling,
+ResamplingInsample = R6Class("ResamplingInsample", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingLOO.R
+++ b/R/ResamplingLOO.R
@@ -44,7 +44,7 @@
 #' task$set_col_roles("island", add_to = "group")
 #' loo$instantiate(task)
 #' loo$iters # one fold for each level of "island"
-ResamplingLOO = R6Class("ResamplingLOO", inherit = Resampling,
+ResamplingLOO = R6Class("ResamplingLOO", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingRepeatedCV.R
+++ b/R/ResamplingRepeatedCV.R
@@ -47,7 +47,7 @@
 #'
 #' # Internal storage:
 #' repeated_cv$instance # table
-ResamplingRepeatedCV = R6Class("ResamplingRepeatedCV", inherit = Resampling,
+ResamplingRepeatedCV = R6Class("ResamplingRepeatedCV", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/R/ResamplingSubsampling.R
+++ b/R/ResamplingSubsampling.R
@@ -39,7 +39,7 @@
 #'
 #' # Internal storage:
 #' subsampling$instance$train # list of index vectors
-ResamplingSubsampling = R6Class("ResamplingSubsampling", inherit = Resampling,
+ResamplingSubsampling = R6Class("ResamplingSubsampling", inherit = ResamplingGroupOrStrata,
   public = list(
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.

--- a/man/mlr_resamplings_bootstrap.Rd
+++ b/man/mlr_resamplings_bootstrap.Rd
@@ -77,8 +77,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingBootstrap}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingBootstrap}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -104,6 +104,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_custom.Rd
+++ b/man/mlr_resamplings_custom.Rd
@@ -54,8 +54,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingCustom}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingCustom}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -74,13 +74,14 @@ Returns the number of resampling iterations, depending on the values stored in t
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="format"><a href='../../mlr3/html/Resampling.html#method-Resampling-format'><code>mlr3::Resampling$format()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="help"><a href='../../mlr3/html/Resampling.html#method-Resampling-help'><code>mlr3::Resampling$help()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_custom_cv.Rd
+++ b/man/mlr_resamplings_custom_cv.Rd
@@ -65,8 +65,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingCustomCV}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingCustomCV}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -85,13 +85,14 @@ Returns the number of resampling iterations, depending on the values stored in t
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="format"><a href='../../mlr3/html/Resampling.html#method-Resampling-format'><code>mlr3::Resampling$format()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="help"><a href='../../mlr3/html/Resampling.html#method-Resampling-help'><code>mlr3::Resampling$help()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_cv.Rd
+++ b/man/mlr_resamplings_cv.Rd
@@ -73,8 +73,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingCV}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingCV}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -100,6 +100,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_holdout.Rd
+++ b/man/mlr_resamplings_holdout.Rd
@@ -74,8 +74,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingHoldout}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingHoldout}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -101,6 +101,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_insample.Rd
+++ b/man/mlr_resamplings_insample.Rd
@@ -55,8 +55,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingInsample}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingInsample}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -82,6 +82,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_loo.Rd
+++ b/man/mlr_resamplings_loo.Rd
@@ -77,8 +77,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingLOO}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingLOO}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -105,6 +105,7 @@ provided to instantiate. Is \code{NA} if the resampling has not been instantiate
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_repeated_cv.Rd
+++ b/man/mlr_resamplings_repeated_cv.Rd
@@ -84,8 +84,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_subsampling}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingRepeatedCV}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingRepeatedCV}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -113,6 +113,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/mlr_resamplings_subsampling.Rd
+++ b/man/mlr_resamplings_subsampling.Rd
@@ -76,8 +76,8 @@ Other Resampling:
 \code{\link{mlr_resamplings_repeated_cv}}
 }
 \concept{Resampling}
-\section{Super class}{
-\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{ResamplingSubsampling}
+\section{Super classes}{
+\code{\link[mlr3:Resampling]{mlr3::Resampling}} -> \code{mlr3::ResamplingGroupOrStrata} -> \code{ResamplingSubsampling}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -103,6 +103,7 @@ Returns the number of resampling iterations, depending on the values stored in t
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="print"><a href='../../mlr3/html/Resampling.html#method-Resampling-print'><code>mlr3::Resampling$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="test_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-test_set'><code>mlr3::Resampling$test_set()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="mlr3" data-topic="Resampling" data-id="train_set"><a href='../../mlr3/html/Resampling.html#method-Resampling-train_set'><code>mlr3::Resampling$train_set()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="mlr3" data-topic="ResamplingGroupOrStrata" data-id="get_instance"><a href='../../mlr3/html/ResamplingGroupOrStrata.html#method-ResamplingGroupOrStrata-get_instance'><code>mlr3::ResamplingGroupOrStrata$get_instance()</code></a></span></li>
 </ul>
 </details>
 }}


### PR DESCRIPTION
This PR adds a new class ResamplingGroupOrStrata in between Resampling and the user-facing classes like ResamplingCV.

The idea is that the get_instance() method is defined in ResamplingGroupOrStrata because it is common to user-facing classes like ResamplingCV and ResamplingLOO, but I want to implement a different get_instance() method in mlr3resampling package (while keeping all the other logic of the Resampling class).

@sebffischer
Does that make sense to you?
In combination with https://github.com/tdhock/mlr3resampling/pull/31, it solves https://github.com/tdhock/mlr3resampling/issues/29 for me.
Please review and/or suggest alternatives.