### PR TITLE
fix: sprintf in autotest

### DIFF
--- a/inst/testthat/helper_autotest.R
+++ b/inst/testthat/helper_autotest.R
@@ -300,6 +300,7 @@ run_experiment = function(task, learner, seed = NULL, configure_learner = NULL) 
 
   # function to collect error message and objects
   err = function(info, ...) {
+    info = gsub("%", "", info)
     info = sprintf(info, ...)
     list(
       ok = FALSE, seed = seed,


### PR DESCRIPTION
### Problem description
This PR fixes an issue in the autotest (`helper_autotest`) where error messages were constructed using `sprintf(info, ...)` within the `err()` function. This caused tests to fail when error messages contained unescaped "%" characters (e.g., from matrix multiplication or other operations that return messages with "%" symbols).

### Proposed fix 
Remove "%" characters from the info string (= error message) before passing it to `sprintf()`. 