### PR TITLE
fix(PredictionDataRegr): pass quantile attributes in concat

### DIFF
--- a/R/PredictionDataRegr.R
+++ b/R/PredictionDataRegr.R
@@ -110,11 +110,18 @@ c.PredictionDataRegr = function(..., keep_duplicates = TRUE) { # nolint
     error_input("Cannot rbind predictions: Some predictions have extra data, others do not")
   }
 
-  elems = c("row_ids", "truth", intersect(predict_types[[1L]], c("response", "se")), if ("weights" %chin% names(dots[[1L]])) "weights")
+  nn = names(dots[[1L]])
+  elems = c("row_ids", "truth", intersect(predict_types[[1L]], c("response", "se")), if ("weights" %chin% nn) "weights")
   tab = map_dtr(dots, function(x) x[elems], .fill = FALSE)
-  quantiles = do.call(rbind, map(dots, "quantiles"))
 
-  extra = if ("extra" %chin% names(dots[[1L]])) {
+  quantiles = if ("quantiles" %chin% nn) {
+    quantiles = map(dots, "quantiles")
+    attrs = attributes(quantiles[[1L]])
+    quantiles = do.call(rbind, quantiles)
+    setattr(quantiles, "probs", attrs$props)
+    setattr(quantiles, "response", attrs$response)
+  }
+  extra = if ("extra" %chin% nn) {
     rbindlist(map(dots, "extra"), fill = TRUE, use.names = TRUE)
   }
 

--- a/R/PredictionRegr.R
+++ b/R/PredictionRegr.R
@@ -65,7 +65,7 @@ PredictionRegr = R6Class("PredictionRegr", inherit = Prediction,
       weights = NULL,
       check = TRUE,
       extra = NULL
-      ) {
+    ) {
       pdata = new_prediction_data(
         list(row_ids = row_ids, truth = truth, response = response, se = se, quantiles = quantiles, distr = distr, weights = weights, extra = extra),
         task_type = "regr"


### PR DESCRIPTION
I've not added assertions for having the same attributes of all quantiles, but this could also be added like for the other cases.