### PR TITLE
perf: vectorize row-wise NA check in prediction fallback path

### DIFF
--- a/R/LearnerClassif.R
+++ b/R/LearnerClassif.R
@@ -129,7 +129,7 @@ LearnerClassif = R6Class(
       }
 
       if (!is.null(pred$prob)) {
-        miss = miss | apply(pred$prob, 1L, anyMissing)
+        miss = miss | row_any_na(pred$prob)
       }
 
       miss_ids = which(miss)

--- a/R/LearnerRegr.R
+++ b/R/LearnerRegr.R
@@ -124,7 +124,7 @@ LearnerRegr = R6Class(
       }
 
       if (!is.null(pred$quantiles)) {
-        miss = miss | apply(pred$quantiles, 1L, anyMissing)
+        miss = miss | row_any_na(pred$quantiles)
       }
 
       miss_ids = which(miss)

--- a/R/PredictionDataClassif.R
+++ b/R/PredictionDataClassif.R
@@ -78,7 +78,7 @@ is_missing_prediction_data.PredictionDataClassif = function(pdata, ...) {
     miss = is.na(pdata$response)
   }
   if (!is.null(pdata$prob)) {
-    miss = miss | apply(pdata$prob, 1L, anyMissing)
+    miss = miss | row_any_na(pdata$prob)
   }
 
   # weights may never be NA, so we don't need to check for missingness

--- a/R/PredictionDataRegr.R
+++ b/R/PredictionDataRegr.R
@@ -83,7 +83,7 @@ is_missing_prediction_data.PredictionDataRegr = function(pdata, ...) {
   }
 
   if (!is.null(pdata$quantiles)) {
-    miss = miss | apply(pdata$quantiles, 1L, anyMissing)
+    miss = miss | row_any_na(pdata$quantiles)
   }
 
   # weights may never be NA, so we don't need to check for missingness

--- a/R/helper.R
+++ b/R/helper.R
@@ -48,6 +48,13 @@ clone_rep = function(x, n) {
   lapply(seq_len(n), function(i) xc)
 }
 
+row_any_na = function(x) {
+  if (!anyNA(x)) {
+    return(logical(nrow(x)))
+  }
+  rowSums(is.na(x)) > 0L
+}
+
 #' @title Assert Validate
 #' @description
 #' Asserts whether the input is a valid value for the `$validate` field of a [`Learner`].


### PR DESCRIPTION
`bench::mark`, 2000 iterations, medians shown.

| matrix     | `apply(x, 1L, anyMissing)` | `row_any_na(x)` (no NA) | speedup (no NA) | `row_any_na(x)` (with NA) | speedup (with NA) |
| ---------- | -------------------------- | ----------------------- | --------------- | ------------------------- | ----------------- |
| 100 × 2    | 59µs                       | 0.66µs                  | ~90×            | 2.5µs                     | ~24×              |
| 100 × 10   | 65µs                       | 0.94µs                  | ~70×            | 3.6µs                     | ~18×              |
| 500 × 5    | 284µs                      | 1.4µs                   | ~200×           | 6.2µs                     | ~45×              |
| 1000 × 5   | 559µs                      | 2.4µs                   | ~230×           | 10.5µs                    | ~53×              |
| 10000 × 5  | 5.52ms                     | 18.9µs                  | ~290×           | 91.7µs                    | ~60×              |
| 10000 × 10 | 5.85ms                     | 37µs                    | ~160×           | 159µs                     | ~37×              |

Memory allocation also drops roughly 2× on the with-NA path and ~15× on the no-NA path (short-circuit returns a pre-sized `logical(nrow)` without materializing `is.na(x)`).
