### PR TITLE
perf: cache class distribution in TaskClassif printer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # mlr3 (development version)
 
+* perf: `TaskClassif$print()` now caches the class distribution of the target column and only recomputes it when the task hash changes.
+  Querying the target column can be slow for tasks with many rows.
+
 # mlr3 1.7.1
 
 * fix: `Learner$new()` and the `$deadline` setter now pass `origin` to `as.POSIXct()`, fixing learner construction and numeric deadline assignment on R versions below 4.3.

--- a/R/TaskClassif.R
+++ b/R/TaskClassif.R
@@ -73,8 +73,7 @@ TaskClassif = R6Class(
       super$print(...)
 
       if (!is.null(private$.backend) && self$nrow <= getOption("mlr3.print_class_ratio_threshold", 1000000L)) {
-        class_freqs = table(self$truth()) / self$nrow * 100
-        class_freqs = class_freqs[order(-class_freqs, names(class_freqs))]
+        class_freqs = private$get_class_freqs()
         classes = if ("twoclass" %in% self$properties) {
           sprintf(
             "%s (positive class, %.0f%%), %s (%.0f%%)",
@@ -165,6 +164,24 @@ TaskClassif = R6Class(
         return(NA_character_)
       }
       lvls[2L]
+    }
+  ),
+
+  private = list(
+    .class_freqs = NULL,
+    .class_freqs_hash = NULL,
+
+    # Relative class frequencies (in percent), sorted decreasingly.
+    # Querying the target column can be slow for tasks with many rows, so the result is cached
+    # and only recomputed when the task hash changed.
+    get_class_freqs = function() {
+      hash = self$hash
+      if (!identical(private$.class_freqs_hash, hash)) {
+        class_freqs = table(self$truth()) / self$nrow * 100
+        private$.class_freqs = class_freqs[order(-class_freqs, names(class_freqs))]
+        private$.class_freqs_hash = hash
+      }
+      private$.class_freqs
     }
   )
 )

--- a/tests/testthat/test_Task.R
+++ b/tests/testthat/test_Task.R
@@ -1113,6 +1113,20 @@ test_that("class ratios are not printed for large tasks (#1382)", {
   expect_output(print(task), "setosa, versicolor, virginica", fixed = TRUE)
 })
 
+test_that("class ratios are cached and invalidated via the task hash", {
+  task = tsk("iris")
+  expect_output(print(task), "setosa \\(33%\\), versicolor \\(33%\\), virginica \\(33%\\)")
+
+  # cache is populated and keyed on the current hash
+  expect_equal(get_private(task)$.class_freqs_hash, task$hash)
+  expect_output(print(task), "setosa \\(33%\\), versicolor \\(33%\\), virginica \\(33%\\)")
+
+  # mutating the task invalidates the cache
+  task$filter(1:60)
+  expect_output(print(task), "setosa \\(83%\\), versicolor \\(17%\\)")
+  expect_equal(get_private(task)$.class_freqs_hash, task$hash)
+})
+
 test_that("id must not contain percent character (#1461)", {
   expect_error(TaskClassif$new("a %>% b", backend = iris, target = "Species"), "must not contain")
   task = tsk("iris")


### PR DESCRIPTION
Querying the target column via `$truth()` can be slow for tasks with many rows, and `TaskClassif$print()` did this on every call. Cache the computed class frequencies and validate the cache against the task hash, which is already invalidated by every task mutator.